### PR TITLE
feat: add crowdin integration

### DIFF
--- a/.github/workflows/crowdin.yaml
+++ b/.github/workflows/crowdin.yaml
@@ -2,7 +2,7 @@ name: Crowdin Action
 
 on:
   push:
-    branches: [ ci/setup-crowdin ]
+    branches: [ main ]
 
 jobs:
   synchronize-with-crowdin:

--- a/.github/workflows/crowdin.yaml
+++ b/.github/workflows/crowdin.yaml
@@ -1,0 +1,34 @@
+name: Crowdin Action
+
+on:
+  push:
+    branches: [ ci/setup-crowdin ]
+
+jobs:
+  synchronize-with-crowdin:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: crowdin action
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: true
+          upload_translations: false
+          download_translations: true
+          localization_branch_name: l10n_crowdin_translations
+          create_pull_request: true
+          pull_request_title: 'New Crowdin Translations'
+          pull_request_body: 'New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)'
+          pull_request_base_branch_name: 'main'
+        env:
+          # A classic GitHub Personal Access Token with the 'repo' scope selected (the user should have write access to the repository).
+          GITHUB_TOKEN: ${{ secrets.GH_CROWDIN_TOKEN }}
+
+          # A numeric ID, found at https://crowdin.com/project/<projectName>/tools/api
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+
+          # Visit https://crowdin.com/settings#api-key to create this token
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,12 @@
+"project_id_env": "CROWDIN_PROJECT_ID"
+"api_token_env": "CROWDIN_PERSONAL_TOKEN"
+"base_path": "composeApp"
+
+"preserve_hierarchy": true
+
+"files": [
+  {
+    "source": "src/commonMain/composeResources/values/strings.xml",
+    "translation": "src/commonMain/composeResources/values-%two_letters_code%/strings.xml"
+  }
+]


### PR DESCRIPTION
This commit introduces Crowdin integration for managing translations. It adds a GitHub Actions workflow for synchronizing with Crowdin, as well as the necessary configuration file.