### PR TITLE
feat: migrate to kotlin.time

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -17,6 +17,10 @@ plugins {
 kotlin {
     jvm("desktop")
 
+    compilerOptions {
+        optIn.add("kotlin.time.ExperimentalTime")
+    }
+
     androidTarget {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
@@ -55,6 +59,7 @@ kotlin {
             implementation(compose.ui)
             implementation(compose.components.resources)
             implementation(compose.components.uiToolingPreview)
+            implementation(libs.kotlin.stdlib)
             implementation(libs.androidx.lifecycle.viewmodel)
             implementation(libs.androidx.lifecycle.runtime.compose)
             implementation(libs.lifecycle.viewmodel.compose)

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/client/ComwattApi.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/client/ComwattApi.kt
@@ -18,9 +18,7 @@ import io.ktor.util.date.GMTDate
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
-import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.minus
 import kotlinx.datetime.toLocalDateTime
@@ -40,7 +38,9 @@ import net.thevenot.comwatt.model.type.AggregationType
 import net.thevenot.comwatt.model.type.MeasureKind
 import net.thevenot.comwatt.model.type.TimeAgoUnit
 import net.thevenot.comwatt.utils.toZoneString
+import kotlin.time.Clock
 import kotlin.time.Duration
+import kotlin.time.Instant
 
 class ComwattApi(val client: HttpClient, val baseUrl: String) {
     suspend fun authenticate(

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/domain/FetchSiteDailyDataUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/domain/FetchSiteDailyDataUseCase.kt
@@ -6,8 +6,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flow
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.format
@@ -20,6 +18,8 @@ import net.thevenot.comwatt.model.ApiError
 import net.thevenot.comwatt.model.type.AggregationLevel
 import net.thevenot.comwatt.model.type.AggregationType
 import net.thevenot.comwatt.model.type.MeasureKind
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 class FetchSiteDailyDataUseCase(private val dataRepository: DataRepository) {
 

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/domain/FetchSiteRealtimeDataUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/domain/FetchSiteRealtimeDataUseCase.kt
@@ -6,9 +6,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flow
-import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
-import kotlinx.datetime.Instant
 import kotlinx.datetime.format
 import kotlinx.datetime.format.DateTimeComponents
 import kotlinx.datetime.minus
@@ -18,6 +16,8 @@ import net.thevenot.comwatt.domain.exception.DomainError
 import net.thevenot.comwatt.domain.model.SiteRealtimeData
 import net.thevenot.comwatt.domain.model.TrendCalculator
 import net.thevenot.comwatt.model.ApiError
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 class FetchSiteRealtimeDataUseCase(private val dataRepository: DataRepository) {
     operator fun invoke(): Flow<Either<DomainError, SiteRealtimeData>> = flow {

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/domain/FetchTimeSeriesUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/domain/FetchTimeSeriesUseCase.kt
@@ -28,8 +28,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import net.thevenot.comwatt.DataRepository
 import net.thevenot.comwatt.domain.exception.DomainError
 import net.thevenot.comwatt.domain.model.ChartTimeSeries
@@ -49,8 +47,10 @@ import net.thevenot.comwatt.model.type.MeasureKind
 import net.thevenot.comwatt.model.type.TimeAgoUnit
 import net.thevenot.comwatt.ui.dashboard.ChartStatistics
 import org.jetbrains.compose.resources.getString
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 
 class FetchTimeSeriesUseCase(private val dataRepository: DataRepository) {
     operator fun invoke(parametersProvider: () -> FetchParameters): Flow<Either<DomainError, List<ChartTimeSeries>>> =

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/domain/FetchWeatherUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/domain/FetchWeatherUseCase.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Instant
 import net.thevenot.comwatt.DataRepository
 import net.thevenot.comwatt.domain.exception.DomainError
 import net.thevenot.comwatt.domain.model.DailyWeather
@@ -21,6 +20,7 @@ import net.thevenot.comwatt.model.DailyWeatherDto
 import net.thevenot.comwatt.model.DailyWeatherResponseDto
 import net.thevenot.comwatt.model.SiteDto
 import net.thevenot.comwatt.model.WeatherConditionDto
+import kotlin.time.Instant
 
 class FetchWeatherUseCase(private val dataRepository: DataRepository) {
 

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/domain/model/SiteDailyData.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/domain/model/SiteDailyData.kt
@@ -1,6 +1,6 @@
 package net.thevenot.comwatt.domain.model
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 data class SiteDailyData(
     val totalProduction: Double = 0.0,

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/domain/model/SiteRealtimeData.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/domain/model/SiteRealtimeData.kt
@@ -1,6 +1,6 @@
 package net.thevenot.comwatt.domain.model
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 data class SiteRealtimeData(
     val production: Double = Double.NaN,

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/domain/model/TimeSeries.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/domain/model/TimeSeries.kt
@@ -1,7 +1,7 @@
 package net.thevenot.comwatt.domain.model
 
-import kotlinx.datetime.Instant
 import net.thevenot.comwatt.ui.dashboard.ChartStatistics
+import kotlin.time.Instant
 
 data class ChartTimeSeries(
     val name: String?,

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/domain/model/Weather.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/domain/model/Weather.kt
@@ -1,6 +1,6 @@
 package net.thevenot.comwatt.domain.model
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 data class WeatherForecast(
     val cityName: String,

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/domain/utils/SiteStatsCalculator.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/domain/utils/SiteStatsCalculator.kt
@@ -1,9 +1,9 @@
 package net.thevenot.comwatt.domain.utils
 
-import kotlinx.datetime.Instant
 import kotlinx.datetime.format
 import kotlinx.datetime.format.DateTimeComponents
 import net.thevenot.comwatt.domain.model.SiteDailyData
+import kotlin.time.Instant
 
 /**
  * Compute totals and rates from site series values.

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/domain/utils/TimeSeriesDownsampler.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/domain/utils/TimeSeriesDownsampler.kt
@@ -1,8 +1,8 @@
 package net.thevenot.comwatt.domain.utils
 
-import kotlinx.datetime.Instant
 import net.thevenot.comwatt.domain.model.TimeUnit
 import kotlin.math.abs
+import kotlin.time.Instant
 
 object TimeSeriesDownsampler {
     fun downsample(

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreenContent.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreenContent.kt
@@ -99,7 +99,6 @@ import comwatt.composeapp.generated.resources.week_range_selected_time_one_week_
 import comwatt.composeapp.generated.resources.week_range_selected_time_past_seven_days
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.format
@@ -132,6 +131,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 
 private val LegendLabelKey = ExtraStore.Key<Set<String>>()
 private const val TAG = "DashboardScreenContent"

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreenState.kt
@@ -1,9 +1,7 @@
 package net.thevenot.comwatt.ui.dashboard
 
-import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.DayOfWeek
-import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.minus
@@ -11,6 +9,8 @@ import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 import net.thevenot.comwatt.domain.model.SiteDailyData
 import net.thevenot.comwatt.ui.dashboard.types.DashboardTimeUnit
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 data class DashboardScreenState(
     val isRefreshing: Boolean = false,

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardViewModel.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.datetime.DateTimeUnit
-import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.minus
 import net.thevenot.comwatt.DataRepository
@@ -28,6 +27,7 @@ import net.thevenot.comwatt.model.type.AggregationLevel
 import net.thevenot.comwatt.model.type.AggregationType
 import net.thevenot.comwatt.model.type.MeasureKind
 import net.thevenot.comwatt.ui.dashboard.types.DashboardTimeUnit
+import kotlin.time.Instant
 
 class DashboardViewModel(
     private val fetchTimeSeriesUseCase: FetchTimeSeriesUseCase,

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/TimePickerDialog.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/TimePickerDialog.kt
@@ -13,7 +13,6 @@ import comwatt.composeapp.generated.resources.Res
 import comwatt.composeapp.generated.resources.day_range_dialog_picker_confirm_button
 import comwatt.composeapp.generated.resources.day_range_dialog_picker_dismiss_button
 import comwatt.composeapp.generated.resources.day_range_dialog_picker_title
-import kotlinx.datetime.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import net.thevenot.comwatt.ui.dashboard.pickers.CustomPicker
@@ -22,6 +21,7 @@ import net.thevenot.comwatt.ui.dashboard.pickers.HourPicker
 import net.thevenot.comwatt.ui.dashboard.pickers.WeekPicker
 import net.thevenot.comwatt.ui.dashboard.types.DashboardTimeUnit
 import org.jetbrains.compose.resources.stringResource
+import kotlin.time.Clock
 
 @Composable
 fun TimePickerDialog(

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/pickers/CustomPicker.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/pickers/CustomPicker.kt
@@ -42,8 +42,6 @@ import comwatt.composeapp.generated.resources.custom_range_dialog_picker_end_tit
 import comwatt.composeapp.generated.resources.custom_range_dialog_picker_start_cannot_be_in_future_error
 import comwatt.composeapp.generated.resources.custom_range_dialog_picker_start_must_be_before_end_error
 import comwatt.composeapp.generated.resources.custom_range_dialog_picker_start_title
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
@@ -56,7 +54,9 @@ import net.thevenot.comwatt.utils.formatHourMinutes
 import net.thevenot.comwatt.utils.formatYearMonthDay
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
+import kotlin.time.Instant
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/pickers/DayPicker.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/pickers/DayPicker.kt
@@ -7,12 +7,12 @@ import androidx.compose.material3.SelectableDates
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.minus
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Instant
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/pickers/HourPicker.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/pickers/HourPicker.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.unit.dp
 import comwatt.composeapp.generated.resources.Res
 import comwatt.composeapp.generated.resources.hour_range_dialog_picker_yesterday_label
 import comwatt.composeapp.generated.resources.hour_range_selected_time
-import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
@@ -37,6 +36,7 @@ import net.thevenot.comwatt.utils.formatHourMinutes
 import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import kotlin.time.Clock
 
 @Composable
 fun HourPicker(

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/pickers/WeekPicker.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/pickers/WeekPicker.kt
@@ -28,7 +28,6 @@ import comwatt.composeapp.generated.resources.Res
 import comwatt.composeapp.generated.resources.week_range_selected_time_n_weeks_ago
 import comwatt.composeapp.generated.resources.week_range_selected_time_one_week_ago
 import comwatt.composeapp.generated.resources.week_range_selected_time_past_seven_days
-import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
@@ -43,6 +42,7 @@ import net.thevenot.comwatt.ui.theme.AppTheme
 import net.thevenot.comwatt.ui.theme.ComwattTheme
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import kotlin.time.Clock
 
 @Composable
 fun WeekPicker(

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeScreenState.kt
@@ -1,9 +1,9 @@
 package net.thevenot.comwatt.ui.home
 
-import kotlinx.datetime.Instant
 import net.thevenot.comwatt.domain.model.SiteDailyData
 import net.thevenot.comwatt.domain.model.SiteRealtimeData
 import net.thevenot.comwatt.domain.model.WeatherForecast
+import kotlin.time.Instant
 
 data class HomeScreenState(
     val isRefreshing: Boolean = false,

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeViewModel.kt
@@ -15,11 +15,12 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Clock
+import kotlinx.datetime.toDeprecatedInstant
 import net.thevenot.comwatt.domain.FetchCurrentSiteUseCase
 import net.thevenot.comwatt.domain.FetchSiteDailyDataUseCase
 import net.thevenot.comwatt.domain.FetchSiteRealtimeDataUseCase
 import net.thevenot.comwatt.domain.FetchWeatherUseCase
+import kotlin.time.Clock
 
 
 class HomeViewModel(
@@ -191,7 +192,7 @@ class HomeViewModel(
     }
 
     fun updateSunState(lat: Double, lon: Double) {
-        val sunState = Clock.System.now().calculateSolarState(
+        val sunState = Clock.System.now().toDeprecatedInstant().calculateSolarState(
             latitude = lat,
             longitude = lon,
         )

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/weather/WeatherCard.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/weather/WeatherCard.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import comwatt.composeapp.generated.resources.Res
 import comwatt.composeapp.generated.resources.weather_day_today
-import kotlinx.datetime.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import net.thevenot.comwatt.domain.model.DailyWeather
@@ -40,6 +39,7 @@ import net.thevenot.comwatt.ui.theme.getWeatherIcon
 import net.thevenot.comwatt.utils.DateFormatter
 import org.jetbrains.compose.resources.stringResource
 import kotlin.math.roundToInt
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/utils/DateTimeUtils.kt
+++ b/composeApp/src/commonMain/kotlin/net/thevenot/comwatt/utils/DateTimeUtils.kt
@@ -1,6 +1,5 @@
 package net.thevenot.comwatt.utils
 
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
@@ -12,6 +11,7 @@ import kotlinx.datetime.format.MonthNames
 import kotlinx.datetime.format.byUnicodePattern
 import kotlinx.datetime.format.char
 import kotlinx.datetime.offsetAt
+import kotlin.time.Instant
 
 @OptIn(FormatStringsInDatetimeFormats::class)
 fun Instant.toZoneString(timeZone: TimeZone = TimeZone.UTC): String {

--- a/composeApp/src/commonTest/kotlin/net/thevenot/comwatt/client/ComwattApiTest.kt
+++ b/composeApp/src/commonTest/kotlin/net/thevenot/comwatt/client/ComwattApiTest.kt
@@ -4,12 +4,12 @@ import com.goncalossilva.resources.Resource
 import io.ktor.http.HttpMethod
 import io.ktor.http.Url
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Instant
 import net.thevenot.comwatt.utils.configureMockEngine
 import net.thevenot.comwatt.utils.mockHttpClient
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Instant
 
 class ComwattApiTest {
     @Test

--- a/composeApp/src/commonTest/kotlin/net/thevenot/comwatt/domain/utils/SiteStatsCalculatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/net/thevenot/comwatt/domain/utils/SiteStatsCalculatorTest.kt
@@ -1,8 +1,8 @@
 package net.thevenot.comwatt.domain.utils
 
-import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Instant
 
 class SiteStatsCalculatorTest {
     @Test

--- a/composeApp/src/commonTest/kotlin/net/thevenot/comwatt/domain/utils/TimeSeriesDownsamplerTest.kt
+++ b/composeApp/src/commonTest/kotlin/net/thevenot/comwatt/domain/utils/TimeSeriesDownsamplerTest.kt
@@ -1,9 +1,10 @@
 package net.thevenot.comwatt.domain.utils
-import kotlinx.datetime.Instant
+
 import net.thevenot.comwatt.domain.model.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Instant
 
 class TimeSeriesDownsamplerTest {
     @Test

--- a/composeApp/src/commonTest/kotlin/net/thevenot/comwatt/ui/dashboard/ChartStatisticsTest.kt
+++ b/composeApp/src/commonTest/kotlin/net/thevenot/comwatt/ui/dashboard/ChartStatisticsTest.kt
@@ -2,12 +2,12 @@ package net.thevenot.comwatt.ui.dashboard
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
-import kotlinx.datetime.Instant
 import net.thevenot.comwatt.domain.model.TimeSeries
 import net.thevenot.comwatt.domain.model.TimeSeriesTitle
 import net.thevenot.comwatt.domain.model.TimeSeriesType
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Instant
 
 class ChartStatisticsTest {
 

--- a/composeApp/src/commonTest/kotlin/net/thevenot/comwatt/utils/DateTimeUtilsTest.kt
+++ b/composeApp/src/commonTest/kotlin/net/thevenot/comwatt/utils/DateTimeUtilsTest.kt
@@ -1,9 +1,9 @@
 package net.thevenot.comwatt.utils
 
-import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Instant
 
 class DateTimeUtilsTest {
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,14 +12,14 @@ androidx-material = "1.12.0"
 androidx-test-junit = "1.3.0"
 compose-multiplatform = "1.8.2"
 junit = "4.13.2"
-kotlin = "2.2.0"
+kotlin = "2.2.20"
 ktor = "3.1.1"
-datetime = "0.6.2"
+datetime = "0.7.1-0.6.x-compat"
 coroutines = "1.10.2"
 navigationCompose = "2.9.0-beta03"
 sha2 = "0.7.1"
 uriKmp = "0.0.20"
-ksp = "2.2.0-2.0.2"
+ksp = "2.2.20-2.0.2"
 sqlite = "2.5.2"
 androidx-room = "2.7.2"
 dataStoreVersion = "1.1.7"
@@ -33,6 +33,7 @@ compose-hot-reload = "1.0.0-beta07"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidx-core-ktx" }


### PR DESCRIPTION
- bump kotlin to 2.2.20
- migrate from kotlinx.datetime to kotlin.time