### PR TITLE
ci: use PAT for Release Please to trigger CI on its PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}


### PR DESCRIPTION
GitHub does not trigger workflows on events created by GITHUB_TOKEN. Using a PAT allows the Release Please PR to trigger the CI check workflow.