### PR TITLE
fix(ios): let Compose handle all safe area insets

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1,6 +1,6 @@
-import UIKit
-import SwiftUI
 import ComposeApp
+import SwiftUI
+import UIKit
 
 struct ComposeView: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewController {
@@ -13,9 +13,6 @@ struct ComposeView: UIViewControllerRepresentable {
 struct ContentView: View {
     var body: some View {
         ComposeView()
-                .ignoresSafeArea(.keyboard) // Compose has own keyboard handler
+            .ignoresSafeArea(.all)  // Compose handles all insets via Scaffold
     }
 }
-
-
-


### PR DESCRIPTION
Changed .ignoresSafeArea(.keyboard) to .ignoresSafeArea(.all) so that Compose Multiplatform's Scaffold manages status bar and home indicator insets directly, matching Android behavior and fixing double-padding and title misalignment on iOS.