### PR TITLE
fix(build): resolve Firebase dependency in release builds

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -160,7 +160,7 @@ dependencies {
     implementation(projects.shared)
 
     // Activity Compose (for MainActivity)
-    implementation("androidx.activity:activity-compose:1.13.0")
+    implementation(libs.androidx.activity.compose)
 
     // Compose tooling for preview and debugging
     implementation(libs.compose.ui.tooling.preview)
@@ -179,6 +179,7 @@ dependencies {
     implementation(libs.ktor.serialization.kotlinx.json)
 
     if (isReleaseBuild) {
+        implementation(platform(libs.firebase.bom))
         implementation(libs.gitlive.firebase.kotlin.crashlytics)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+activityCompose = "1.13.0"
 agp = "9.0.1"
 android-compileSdk = "36"
 android-minSdk = "24"
@@ -23,12 +24,14 @@ vico = "2.5.0"
 
 gradlePlugins-crashlytics = "3.0.7"
 gradlePlugins-google-services = "4.4.4"
+firebase-bom = "33.7.0"
 firebase-gitlive-sdk = "2.4.0"
 material3 = "1.10.0-alpha05"
 androidx-glance = "1.1.1"
 androidx-work = "2.11.2"
 
 [libraries]
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 
@@ -63,6 +66,7 @@ vico = { group = "com.patrykandpatrick.vico", name = "multiplatform", version.re
 vico-multiplatform-m3 = { group = "com.patrykandpatrick.vico", name = "multiplatform-m3", version.ref = "vico" }
 test-resources = { module = "com.goncalossilva:resources", version.ref = "testResources" }
 kastro = { module = "dev.jamesyox:kastro", version = "0.5.0" }
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
 gitlive-firebase-kotlin-crashlytics = { module = "dev.gitlive:firebase-crashlytics", version.ref = "firebase-gitlive-sdk" }
 androidx-glance = { group = "androidx.glance", name = "glance-appwidget", version.ref = "androidx-glance" }
 androidx-glance-material3 = { group = "androidx.glance", name = "glance-material3", version.ref = "androidx-glance" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -78,9 +78,6 @@ kotlin {
         androidMain.dependencies {
             implementation(libs.compose.ui.tooling.preview)
             implementation(libs.ktor.client.android)
-            if (isReleaseBuild) {
-                api(libs.gitlive.firebase.kotlin.crashlytics)
-            }
         }
         commonMain.dependencies {
             implementation(libs.compose.runtime)


### PR DESCRIPTION
Move Firebase Crashlytics from shared/androidMain to androidApp only, and add the Firebase BOM so transitive deps resolve without the Google Services plugin in the shared module.