### PR TITLE
fix(ci): rename Android artifacts after build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,14 @@ jobs:
             -PVERSION_CODE="${{ steps.version.outputs.code }}" \
             --parallel
 
+      - name: Rename Android artifacts
+        run: |
+          VERSION="${{ steps.version.outputs.name }}"
+          mv androidApp/build/outputs/apk/release/androidApp-release.apk \
+             androidApp/build/outputs/apk/release/solareco-${VERSION}-release.apk
+          mv androidApp/build/outputs/bundle/release/androidApp-release.aab \
+             androidApp/build/outputs/bundle/release/solareco-${VERSION}-release.aab
+
       - name: Build iOS framework
         run: ./gradlew :shared:linkReleaseFrameworkIosArm64
 


### PR DESCRIPTION
AGP 9.0 removed archivesBaseName support, so APK/AAB are now produced as androidApp-release.{apk,aab}. Rename them to the expected solareco-VERSION-release format before uploading to the release.