### PR TITLE
fix(widget): add ProGuard keep rules for Glance and WorkManager classes

### DIFF
--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -19,5 +19,16 @@
 
 # Room ships consumer rules; no additional rules required here.
 
+# Glance ActionCallback classes are instantiated via reflection by the framework.
+# AGP 9 may not pick up Glance's consumer rules correctly.
+-keep class * implements androidx.glance.appwidget.action.ActionCallback { <init>(); }
+
+# GlanceAppWidget and GlanceAppWidgetReceiver are resolved by name from the manifest.
+-keep class * extends androidx.glance.appwidget.GlanceAppWidget { *; }
+-keep class * extends androidx.glance.appwidget.GlanceAppWidgetReceiver { *; }
+
+# WorkManager workers are instantiated via reflection by WorkerFactory.
+-keep class * extends androidx.work.ListenableWorker { <init>(android.content.Context, androidx.work.WorkerParameters); }
+
 # If you see specific warnings during shrink, add targeted -dontwarn entries rather than broad -dontoptimize.
 


### PR DESCRIPTION
R8 was stripping the no-arg constructor of RefreshWidgetAction (ActionCallback), causing a NoSuchMethodException at runtime when Glance tries to instantiate it via reflection.

This is a regression from the AGP 9 migration — consumer ProGuard rules from Glance and WorkManager libraries are not being picked up correctly.

Added explicit keep rules for:
- ActionCallback implementations (no-arg constructor)
- GlanceAppWidget and GlanceAppWidgetReceiver subclasses
- ListenableWorker subclasses (2-arg constructor)