### PR TITLE
fix(widget): wrap PowerStat icon+text in Row to prevent clipping

### DIFF
--- a/androidApp/src/main/kotlin/net/thevenot/comwatt/widget/ConsumptionWidgetContent.kt
+++ b/androidApp/src/main/kotlin/net/thevenot/comwatt/widget/ConsumptionWidgetContent.kt
@@ -203,20 +203,22 @@ private fun PowerStatsRow(context: Context, widgetData: WidgetConsumptionData) {
 
 @Composable
 private fun PowerStat(iconRes: Int, value: Int, contentDescription: String) {
-    Image(
-        provider = ImageProvider(iconRes),
-        contentDescription = contentDescription,
-        modifier = GlanceModifier.size(14.dp)
-    )
-    Spacer(modifier = GlanceModifier.width(AppTheme.dimens.paddingTooSmall))
-    Text(
-        text = "${value}W",
-        style = TextStyle(
-            fontSize = 12.sp,
-            fontWeight = FontWeight.Bold,
-            color = GlanceTheme.colors.onSurface
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Image(
+            provider = ImageProvider(iconRes),
+            contentDescription = contentDescription,
+            modifier = GlanceModifier.size(14.dp)
         )
-    )
+        Spacer(modifier = GlanceModifier.width(AppTheme.dimens.paddingTooSmall))
+        Text(
+            text = "${value}W",
+            style = TextStyle(
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Bold,
+                color = GlanceTheme.colors.onSurface
+            )
+        )
+    }
 }
 
 @Composable


### PR DESCRIPTION
The Image, Spacer, and Text were emitted as loose siblings in the parent Row. In Glance (RemoteViews), when horizontal space runs out, later children get clipped silently — the sun icon would render but its value text would be cut off.

Wrapping in an inner Row makes each stat an atomic unit.