### PR TITLE
fix(model): make TempoDayValue nullable in DayStatusDto

### DIFF
--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/model/ElectricityPriceDto.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/model/ElectricityPriceDto.kt
@@ -35,7 +35,7 @@ data class DailyElectricityPriceDto(
 
 @Serializable
 data class DayStatusDto(
-    val value: TempoDayValue,
+    val value: TempoDayValue?,
     val type: PeakType,
     @SerialName("start_time")
     val startTime: String,


### PR DESCRIPTION
API sometimes returns null for value field in day status when tempo status is unavailable