### PR TITLE
feat: add biggest consumer component

### DIFF
--- a/docs/superpowers/specs/2026-06-01-biggest-consumer-component-design.md
+++ b/docs/superpowers/specs/2026-06-01-biggest-consumer-component-design.md
@@ -1,0 +1,370 @@
+---
+name: biggest-consumer-component
+description: Component to display the top 1-2 energy consuming devices across different time contexts (realtime, daily, custom range)
+metadata:
+  type: feature
+  date: 2026-06-01
+---
+
+# Biggest Consumer Component Design
+
+## Overview
+
+Add a reusable component that shows the one or two biggest energy consumers to answer the question "what is consuming most of my energy?" The component will be context-aware, showing different metrics based on where it's displayed:
+
+- **Home page realtime card:** Devices consuming the most power *right now* (instant power)
+- **Home page daily statistics card:** Devices that consumed the most energy *today*
+- **Dashboard statistics card:** Devices consuming most in the *selected time range*
+- **Widget (stretch goal):** Top consumer in the *past hour*
+
+## Architecture
+
+### Component Architecture
+
+Following the existing layered architecture:
+
+**Domain Layer:**
+- `FetchTopConsumersUseCase` - Orchestrates fetching devices and filtering/sorting to find top consumers
+- Returns `Either<DomainError, List<DeviceUiModel>>` for consistent error handling
+
+**UI Layer:**
+- `TopConsumersCard` - Reusable composable displaying 1-2 top consumers
+- Takes `List<DeviceUiModel>` and `ConsumerDisplayMode` as parameters
+- Integrates into `HomeScreen`, `DashboardScreen`, and potentially widgets
+
+### Data Flow
+
+```
+User opens screen
+    → ViewModel calls FetchTopConsumersUseCase
+    → Use case calls DataRepository.api.fetchDevices()
+    → For each device: fetch time series data (instant power or daily energy)
+    → Filter out production/offline devices
+    → Sort devices by consumption metric (descending)
+    → Return top N devices
+    → ViewModel updates state
+    → TopConsumersCard renders the top consumers
+```
+
+## Use Case Design
+
+### Interface
+
+```kotlin
+class FetchTopConsumersUseCase(private val dataRepository: DataRepository) {
+    suspend fun execute(
+        limit: Int = 2,
+        sortBy: ConsumerMetric,
+        startTime: Instant? = null,  // For CUSTOM_RANGE
+        endTime: Instant? = null     // For CUSTOM_RANGE
+    ): Either<DomainError, List<DeviceUiModel>>
+}
+
+enum class ConsumerMetric {
+    INSTANT_POWER,   // For realtime card - uses instantPowerWatts
+    DAILY_ENERGY,    // For daily statistics - uses dailyEnergyWh
+    CUSTOM_RANGE     // For dashboard - fetches energy for startTime/endTime range
+}
+```
+
+### Implementation Strategy
+
+**Reuse existing logic:**
+- Extract device-fetching logic from `FetchDevicesUseCase` (fetches all devices, enriches with time series data)
+- The logic for fetching `instantPowerWatts` and `dailyEnergyWh` already exists in `FetchDevicesUseCase`
+
+**Filtering:**
+- Exclude production devices (`isProduction == true`)
+- Exclude offline devices (`isOnline == false`)
+- Only include devices with valid consumption data (non-null values)
+
+**Sorting:**
+- Sort by the specified metric in descending order (highest consumption first)
+- For `INSTANT_POWER`: sort by `instantPowerWatts`
+- For `DAILY_ENERGY`: sort by `dailyEnergyWh`
+- For `CUSTOM_RANGE`: fetch energy consumption for the range, then sort
+
+**Return:**
+- Take top N devices (default 2)
+- Return empty list if no valid consumers found
+
+**Why:** This keeps the use case focused on answering "who are the top consumers?" while reusing proven device-fetching logic.
+
+**How to apply:** Call this use case from ViewModels when they need top consumer data. The use case handles all the complexity of fetching, filtering, and sorting.
+
+### Edge Cases
+
+| Case | Behavior |
+|------|----------|
+| All devices offline | Return empty list |
+| Only production devices exist | Return empty list |
+| Fewer than N consuming devices | Return all available consumers |
+| API errors | Propagate as `Either.Left(DomainError.Api(...))` |
+| Null consumption values | Filter out those devices |
+
+### Performance Considerations
+
+**API Call Count:**
+With 10 devices, this adds:
+- 1 call to fetch device list
+- 10 × 2 calls for time series data (instant power + daily energy)
+- **Total: 21 API calls**
+
+**Why this is acceptable:**
+- Comwatt's own website makes the same calls
+- No caching in v1 - always fetch fresh data (Option B from discussion)
+- Simple implementation, can optimize later if needed
+
+**How to apply:** Start with no caching. If performance becomes an issue, add short-lived cache (30-60s TTL) in a future iteration.
+
+## UI Component Design
+
+### Component Interface
+
+```kotlin
+@Composable
+fun TopConsumersCard(
+    devices: List<DeviceUiModel>,
+    displayMode: ConsumerDisplayMode,
+    modifier: Modifier = Modifier,
+    title: String? = null,           // Optional custom title
+    isLoading: Boolean = false
+)
+
+enum class ConsumerDisplayMode {
+    INSTANT_POWER,        // Shows "2.5 kW"
+    ENERGY,               // Shows "12.3 kWh"
+    ENERGY_WITH_PERIOD    // Shows "12.3 kWh / 24h" or custom period
+}
+```
+
+### Visual Design
+
+**Layout: Compact horizontal rows** (Option 1)
+
+Shows each device in a row format:
+```
+[Icon] Device Name          2.5 kW
+[Icon] Device Name          1.8 kW
+```
+
+**Elements per device:**
+1. **Device icon** - Color-coded circle with device type icon
+   - Reuse `getDeviceIconPainter()` from `DevicesScreen`
+   - Icon tint uses `MaterialTheme.colorScheme.powerConsumption`
+2. **Device name** - Primary text, ellipsized if too long
+3. **Consumption value** - Bold, prominent display with unit
+4. **Optional: Progress bar** - Shows relative consumption between top devices
+
+**Why:** Compact layout fits well in existing cards without taking excessive vertical space. Consistent with the app's design system (Material 3, elevated cards). Can iterate to add more visual elements (progress bars, device categories) in future versions.
+
+**How to apply:** Use existing theme colors, spacing (AppTheme.dimens), and typography. Reuse device icon logic from DevicesScreen. Add Compose previews for different states.
+
+### Component States
+
+- **Loading:** Show skeleton/placeholder
+- **Empty:** Don't render (graceful degradation)
+- **1 device:** Show single row
+- **2 devices:** Show two rows with relative comparison
+
+### Compose Previews
+
+Add preview composables for:
+- Loading state
+- Single device
+- Two devices with different consumption levels
+- Light/dark theme variations
+
+## Integration Points
+
+### Home Screen
+
+**In `HomeScreenState`:**
+```kotlin
+data class HomeScreenState(
+    // ... existing fields
+    val topRealtimeConsumers: List<DeviceUiModel> = emptyList(),
+    val topDailyConsumers: List<DeviceUiModel> = emptyList(),
+)
+```
+
+**In `HomeViewModel`:**
+- Add `FetchTopConsumersUseCase` dependency
+- In `singleRefresh()`: Call use case twice
+  - Once with `ConsumerMetric.INSTANT_POWER` → update `topRealtimeConsumers`
+  - Once with `ConsumerMetric.DAILY_ENERGY` → update `topDailyConsumers`
+
+**In `RealTimeConsumptionSection` composable:**
+Add `TopConsumersCard` after the `PowerFlowBalance`:
+```kotlin
+PowerFlowBalance(uiState = uiState)
+
+if (uiState.topRealtimeConsumers.isNotEmpty()) {
+    TopConsumersCard(
+        devices = uiState.topRealtimeConsumers,
+        displayMode = ConsumerDisplayMode.INSTANT_POWER,
+        title = stringResource(Res.string.top_consumers_realtime_title)
+    )
+}
+```
+
+**In `StatisticsCard` composable:**
+Add optional parameter and render `TopConsumersCard` at the bottom:
+```kotlin
+@Composable
+fun StatisticsCard(
+    siteDailyData: SiteDailyData?,
+    totalsLabel: String,
+    modifier: Modifier = Modifier,
+    title: String? = null,
+    topConsumers: List<DeviceUiModel> = emptyList()  // NEW
+) {
+    // ... existing content
+    
+    if (topConsumers.isNotEmpty()) {
+        TopConsumersCard(
+            devices = topConsumers,
+            displayMode = ConsumerDisplayMode.ENERGY_WITH_PERIOD,
+            title = stringResource(Res.string.top_consumers_daily_title)
+        )
+    }
+}
+```
+
+**Why:** Home screen already has the state management pattern (auto-refresh, pull-to-refresh). Adding top consumers fits naturally into the existing refresh flow. If fetching fails, we simply don't show the component - main screen data still loads.
+
+**How to apply:** Update the ViewModel to fetch top consumers during the existing refresh cycle. Pass the data through state to the composables. Use conditional rendering to only show the component when data is available.
+
+### Dashboard Screen
+
+**In `DashboardScreenState`:**
+```kotlin
+data class DashboardScreenState(
+    // ... existing fields
+    val topConsumers: List<DeviceUiModel> = emptyList(),
+)
+```
+
+**In `DashboardViewModel`:**
+- Add `FetchTopConsumersUseCase` dependency
+- When time range changes, call use case with:
+  - `ConsumerMetric.CUSTOM_RANGE`
+  - `startTime` = selected range start
+  - `endTime` = selected range end
+- Update `topConsumers` in state
+
+**In `ChartStatistics` component:**
+Add `TopConsumersCard` below the statistics display.
+
+**Why:** Dashboard already has time range selection and data refresh logic. The custom range support allows showing "biggest consumers for this week" or any selected period. Fits naturally into the statistics display.
+
+**How to apply:** Trigger top consumer fetch whenever the time range changes (same trigger as chart data fetch). Reuse the existing time range parameters.
+
+### Widget Integration (Stretch Goal)
+
+**In `WidgetStatisticsData`:**
+```kotlin
+data class WidgetStatisticsData(
+    // ... existing fields
+    val topConsumer: DeviceUiModel? = null,  // Just top 1 for space constraints
+)
+```
+
+**In `FetchWidgetStatisticsUseCase`:**
+- Call `FetchTopConsumersUseCase` with:
+  - `limit = 1` (only top device)
+  - `ConsumerMetric.CUSTOM_RANGE`
+  - `startTime` = 1 hour ago
+  - `endTime` = now
+- Include result in returned data
+
+**Widget display:**
+Show simplified view with just icon, name, and consumption value (no room for detailed layout).
+
+**Why:** Widgets have limited space, so showing just the #1 consumer makes sense. The 1-hour window matches the widget's data refresh pattern. This is a stretch goal - can be added after main implementation.
+
+**How to apply:** Widget implementation depends on whether the simplified layout fits Android/iOS widget constraints. Evaluate during implementation - may defer to v2.
+
+## Error Handling
+
+**Use case errors:**
+- API failures → return `Either.Left(DomainError.Api(...))`
+- No site selected → return `Either.Left(DomainError.Generic("No site selected"))`
+
+**ViewModel handling:**
+- Log errors
+- Don't update top consumers state (remains empty)
+- Main screen data still loads successfully
+
+**UI handling:**
+- Empty list → don't render component (graceful degradation)
+- Loading state → optional skeleton UI
+- No error messages shown to user (avoids clutter if secondary feature fails)
+
+**Why:** Top consumers is a nice-to-have feature. If it fails, the main screen functionality (realtime data, daily stats, charts) should still work. Silent failure with logging is appropriate here.
+
+**How to apply:** Check if `topConsumers` list is empty before rendering. Don't show error states to users - just omit the component.
+
+## Testing Strategy
+
+**Use case tests:**
+- Test sorting logic with various device configurations
+- Test filtering (production/offline devices excluded)
+- Test edge cases (empty list, all offline, etc.)
+- Test error propagation
+
+**UI tests:**
+- Compose preview snapshots for all states
+- Manual testing on different screen sizes
+- Verify layout in light/dark themes
+
+**Integration tests:**
+- Test full flow: HomeViewModel → Use Case → UI
+- Verify refresh behavior
+- Test time range selection in Dashboard
+
+## Localization
+
+Add string resources for:
+- `top_consumers_realtime_title` - "Top Consumers Now"
+- `top_consumers_daily_title` - "Biggest Consumers Today"
+- `top_consumers_custom_title` - "Top Consumers"
+
+Follow existing pattern in `composeResources/values/strings.xml`.
+
+## Future Enhancements (Not in v1)
+
+- **Caching:** Add 30-60s TTL cache to reduce API calls
+- **Progress bars:** Show relative consumption between devices
+- **Device categories:** Display category labels (Heating, Appliances, etc.)
+- **Tap to navigate:** Navigate to device detail screen on tap
+- **Animations:** Animate consumption value changes
+- **Historical comparison:** "20% more than yesterday"
+
+## Implementation Checklist
+
+1. Create `ConsumerMetric` enum in domain/model
+2. Create `FetchTopConsumersUseCase` in domain/
+3. Extract common device-fetching logic (shared with `FetchDevicesUseCase`)
+4. Create `ConsumerDisplayMode` enum in ui/common
+5. Create `TopConsumersCard` composable in ui/common/
+6. Add Compose previews for `TopConsumersCard`
+7. Update `HomeScreenState` with top consumer fields
+8. Update `HomeViewModel` to fetch top consumers
+9. Integrate `TopConsumersCard` into `RealTimeConsumptionSection`
+10. Update `StatisticsCard` to accept and display top consumers
+11. Update `DashboardScreenState` with top consumers field
+12. Update `DashboardViewModel` to fetch top consumers
+13. Integrate into Dashboard UI
+14. Add localized strings
+15. Test on real devices with different device counts
+16. (Optional) Widget integration
+
+## Success Criteria
+
+- Component displays correctly in Home screen (realtime and daily cards)
+- Component displays in Dashboard with selected time range
+- Handles edge cases gracefully (no devices, all offline, API errors)
+- Performance acceptable with 10 devices (~21 API calls)
+- UI matches existing design system
+- Compose previews cover all states

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -131,4 +131,9 @@
     <string name="top_consumers_title">Top Consumers</string>
     <string name="top_consumers_realtime_title">Top Consumers Now</string>
     <string name="top_consumers_daily_title">Biggest Consumers Today</string>
+    <string name="top_consumers_past_hour">Biggest Consumers in the Past Hour</string>
+    <string name="top_consumers_past_6h">Biggest Consumers in the Past 6 Hours</string>
+    <string name="top_consumers_today">Biggest Consumers Today</string>
+    <string name="top_consumers_this_week">Biggest Consumers This Week</string>
+    <string name="top_consumers_custom">Biggest Consumers</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -128,4 +128,7 @@
     <string name="device_settings_save_button">Save</string>
     <string name="device_settings_save_success">Device saved successfully</string>
     <string name="device_settings_save_error">Error saving device</string>
+    <string name="top_consumers_title">Top Consumers</string>
+    <string name="top_consumers_realtime_title">Top Consumers Now</string>
+    <string name="top_consumers_daily_title">Biggest Consumers Today</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -131,9 +131,4 @@
     <string name="top_consumers_title">Top Consumers</string>
     <string name="top_consumers_realtime_title">Top Consumers Now</string>
     <string name="top_consumers_daily_title">Biggest Consumers Today</string>
-    <string name="top_consumers_past_hour">Biggest Consumers in the Past Hour</string>
-    <string name="top_consumers_past_6h">Biggest Consumers in the Past 6 Hours</string>
-    <string name="top_consumers_today">Biggest Consumers Today</string>
-    <string name="top_consumers_this_week">Biggest Consumers This Week</string>
-    <string name="top_consumers_custom">Biggest Consumers</string>
 </resources>

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/domain/FetchTopConsumersUseCase.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/domain/FetchTopConsumersUseCase.kt
@@ -1,0 +1,205 @@
+package net.thevenot.comwatt.domain
+
+import arrow.core.Either
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.firstOrNull
+import net.thevenot.comwatt.DataRepository
+import net.thevenot.comwatt.domain.exception.DomainError
+import net.thevenot.comwatt.domain.model.ConsumerMetric
+import net.thevenot.comwatt.domain.model.DeviceCategoryGroup
+import net.thevenot.comwatt.domain.model.DeviceUiModel
+import net.thevenot.comwatt.model.CoState
+import net.thevenot.comwatt.model.DeviceCode
+import net.thevenot.comwatt.model.DeviceDto
+import net.thevenot.comwatt.model.type.AggregationLevel
+import net.thevenot.comwatt.model.type.AggregationType
+import net.thevenot.comwatt.model.type.MeasureKind
+import net.thevenot.comwatt.model.type.TimeAgoUnit
+import kotlin.time.Instant
+
+class FetchTopConsumersUseCase(private val dataRepository: DataRepository) {
+
+    suspend fun execute(
+        limit: Int = 2,
+        sortBy: ConsumerMetric,
+        startTime: Instant? = null,
+        endTime: Instant? = null
+    ): Either<DomainError, List<DeviceUiModel>> {
+        val siteId = dataRepository.getSettings().firstOrNull()?.siteId
+            ?: return Either.Left(DomainError.Generic("No site selected"))
+
+        return try {
+            coroutineScope {
+                val devicesResult = async(Dispatchers.IO) {
+                    dataRepository.api.fetchDevices(siteId)
+                }.await()
+
+                devicesResult.mapLeft { DomainError.Api(it) }.map { devices ->
+                    val deviceModels = devices.map { device ->
+                        async(Dispatchers.IO) {
+                            buildDeviceUiModel(device, sortBy, startTime, endTime)
+                        }
+                    }.awaitAll().filterNotNull()
+
+                    filterAndSort(deviceModels, limit, sortBy)
+                }
+            }
+        } catch (e: Exception) {
+            Logger.e(TAG) { "Error fetching top consumers: ${e.message}" }
+            Either.Left(DomainError.Generic(e.message ?: "Unknown error"))
+        }
+    }
+
+    private suspend fun buildDeviceUiModel(
+        device: DeviceDto,
+        sortBy: ConsumerMetric,
+        startTime: Instant?,
+        endTime: Instant?
+    ): DeviceUiModel? {
+        val deviceId = device.id ?: return null
+        val name = device.name ?: return null
+        val deviceCode = device.deviceKind?.code ?: device.partKind?.code
+        val isOnline = device.coState != CoState.NOT_WORKING && device.sourceIsOnline != false
+        val isProduction = device.production == true || device.deviceKind?.production == true
+
+        var instantPower: Double? = null
+        var dailyEnergy: Double? = null
+
+        if (isOnline && !isProduction) {
+            when (sortBy) {
+                ConsumerMetric.INSTANT_POWER -> {
+                    instantPower = fetchInstantPower(deviceId)
+                }
+                ConsumerMetric.DAILY_ENERGY -> {
+                    dailyEnergy = fetchDailyEnergy(deviceId)
+                }
+                ConsumerMetric.CUSTOM_RANGE -> {
+                    if (startTime != null && endTime != null) {
+                        dailyEnergy = fetchEnergyForRange(deviceId, startTime, endTime)
+                    }
+                }
+            }
+        }
+
+        val category = mapCategory(deviceCode, isProduction)
+        val hasToggle = hasPowerSwitch(device)
+
+        return DeviceUiModel(
+            id = deviceId,
+            name = name.normalizeDeviceName(),
+            deviceCode = deviceCode,
+            isOnline = isOnline,
+            isProduction = isProduction,
+            instantPowerWatts = instantPower,
+            dailyEnergyWh = dailyEnergy,
+            hasToggle = hasToggle,
+            isToggleEnabled = hasToggle && isOnline,
+            category = category,
+        )
+    }
+
+    private suspend fun fetchInstantPower(deviceId: Int): Double? {
+        return try {
+            dataRepository.api.fetchTimeSeries(
+                deviceId = deviceId,
+                timeAgoUnit = TimeAgoUnit.DAY,
+                timeAgoValue = 1,
+                measureKind = MeasureKind.FLOW,
+                aggregationLevel = AggregationLevel.NONE,
+            ).getOrNull()?.let { ts ->
+                if (ts.values.isNotEmpty()) ts.values.last() else null
+            }
+        } catch (e: Exception) {
+            Logger.w(TAG) { "Failed to fetch instant power for device $deviceId: ${e.message}" }
+            null
+        }
+    }
+
+    private suspend fun fetchDailyEnergy(deviceId: Int): Double? {
+        return try {
+            dataRepository.api.fetchTimeSeries(
+                deviceId = deviceId,
+                timeAgoUnit = TimeAgoUnit.DAY,
+                timeAgoValue = 1,
+                measureKind = MeasureKind.QUANTITY,
+                aggregationLevel = AggregationLevel.HOUR,
+                aggregationType = AggregationType.SUM,
+            ).getOrNull()?.let { ts ->
+                if (ts.values.isNotEmpty()) ts.values.sum() else null
+            }
+        } catch (e: Exception) {
+            Logger.w(TAG) { "Failed to fetch daily energy for device $deviceId: ${e.message}" }
+            null
+        }
+    }
+
+    private suspend fun fetchEnergyForRange(
+        deviceId: Int,
+        startTime: Instant,
+        endTime: Instant
+    ): Double? {
+        return try {
+            dataRepository.api.fetchTimeSeries(
+                deviceId = deviceId,
+                startTime = startTime,
+                endTime = endTime,
+                measureKind = MeasureKind.QUANTITY,
+                aggregationLevel = AggregationLevel.HOUR,
+                aggregationType = AggregationType.SUM,
+            ).getOrNull()?.let { ts ->
+                if (ts.values.isNotEmpty()) ts.values.sum() else null
+            }
+        } catch (e: Exception) {
+            Logger.w(TAG) { "Failed to fetch energy for range for device $deviceId: ${e.message}" }
+            null
+        }
+    }
+
+    private fun mapCategory(code: DeviceCode?, isProduction: Boolean): DeviceCategoryGroup {
+        if (isProduction) return DeviceCategoryGroup.PRODUCTION
+        return when (code) {
+            DeviceCode.GRID_METER, DeviceCode.WITHDRAWAL, DeviceCode.INJECTION -> DeviceCategoryGroup.GRID
+            DeviceCode.BATTERY, DeviceCode.BATTERY_CHARGE, DeviceCode.BATTERY_DISCHARGE -> DeviceCategoryGroup.STORAGE
+            DeviceCode.SOLAR_PANEL, DeviceCode.SOLAR_PANEL_RESALE -> DeviceCategoryGroup.PRODUCTION
+            else -> DeviceCategoryGroup.CONSUMPTION
+        }
+    }
+
+    private fun hasPowerSwitch(device: DeviceDto): Boolean {
+        val directCapacities = device.capacities.orEmpty()
+        if (directCapacities.any { it.capacity?.nature == "POWER_SWITCH" }) return true
+        val featureCapacities = device.features.orEmpty().flatMap { it.capacities.orEmpty() }
+        return featureCapacities.any { it.capacity?.nature == "POWER_SWITCH" }
+    }
+
+    companion object {
+        private const val TAG = "FetchTopConsumersUseCase"
+
+        fun filterAndSort(
+            devices: List<DeviceUiModel>,
+            limit: Int,
+            sortBy: ConsumerMetric
+        ): List<DeviceUiModel> {
+            return devices
+                .filter { !it.isProduction && it.isOnline }
+                .filter { device ->
+                    when (sortBy) {
+                        ConsumerMetric.INSTANT_POWER -> device.instantPowerWatts != null && device.instantPowerWatts > 0
+                        ConsumerMetric.DAILY_ENERGY, ConsumerMetric.CUSTOM_RANGE -> device.dailyEnergyWh != null && device.dailyEnergyWh > 0
+                    }
+                }
+                .sortedByDescending { device ->
+                    when (sortBy) {
+                        ConsumerMetric.INSTANT_POWER -> device.instantPowerWatts ?: 0.0
+                        ConsumerMetric.DAILY_ENERGY, ConsumerMetric.CUSTOM_RANGE -> device.dailyEnergyWh ?: 0.0
+                    }
+                }
+                .take(limit)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/domain/model/ConsumerMetric.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/domain/model/ConsumerMetric.kt
@@ -1,0 +1,7 @@
+package net.thevenot.comwatt.domain.model
+
+enum class ConsumerMetric {
+    INSTANT_POWER,
+    DAILY_ENERGY,
+    CUSTOM_RANGE
+}

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/common/ConsumerDisplayMode.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/common/ConsumerDisplayMode.kt
@@ -1,0 +1,7 @@
+package net.thevenot.comwatt.ui.common
+
+enum class ConsumerDisplayMode {
+    INSTANT_POWER,
+    ENERGY,
+    ENERGY_WITH_PERIOD
+}

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/common/TopConsumersCard.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/common/TopConsumersCard.kt
@@ -1,0 +1,331 @@
+package net.thevenot.comwatt.ui.common
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import net.thevenot.comwatt.domain.model.DeviceCategoryGroup
+import net.thevenot.comwatt.domain.model.DeviceUiModel
+import net.thevenot.comwatt.model.DeviceCode
+import net.thevenot.comwatt.ui.theme.AppTheme
+import net.thevenot.comwatt.ui.theme.ComwattTheme
+import net.thevenot.comwatt.ui.theme.icons.AppIcons
+import net.thevenot.comwatt.ui.theme.powerConsumption
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+@Composable
+fun TopConsumersCard(
+    devices: List<DeviceUiModel>,
+    displayMode: ConsumerDisplayMode,
+    modifier: Modifier = Modifier,
+    title: String? = null,
+    isLoading: Boolean = false
+) {
+    if (devices.isEmpty() && !isLoading) {
+        return
+    }
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(AppTheme.dimens.paddingSmall)
+    ) {
+        title?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = AppTheme.dimens.paddingExtraSmall)
+            )
+        }
+
+        devices.forEach { device ->
+            TopConsumerRow(
+                device = device,
+                displayMode = displayMode
+            )
+        }
+    }
+}
+
+@Composable
+private fun TopConsumerRow(
+    device: DeviceUiModel,
+    displayMode: ConsumerDisplayMode,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.weight(1f)
+        ) {
+            DeviceIcon(device)
+            Spacer(modifier = Modifier.width(AppTheme.dimens.paddingSmall))
+            Text(
+                text = device.name,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
+        ConsumptionValue(
+            device = device,
+            displayMode = displayMode
+        )
+    }
+}
+
+@Composable
+private fun DeviceIcon(device: DeviceUiModel) {
+    val iconPainter = getDeviceIconPainter(device.deviceCode)
+    val tint = MaterialTheme.colorScheme.powerConsumption
+
+    Surface(
+        shape = MaterialTheme.shapes.small,
+        color = tint.copy(alpha = 0.12f),
+        modifier = Modifier.size(32.dp)
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Icon(
+                painter = iconPainter,
+                contentDescription = device.name,
+                tint = tint,
+                modifier = Modifier.size(18.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ConsumptionValue(
+    device: DeviceUiModel,
+    displayMode: ConsumerDisplayMode
+) {
+    val valueText = when (displayMode) {
+        ConsumerDisplayMode.INSTANT_POWER -> {
+            device.instantPowerWatts?.let { formatPowerValue(it) } ?: "—"
+        }
+        ConsumerDisplayMode.ENERGY -> {
+            device.dailyEnergyWh?.let { formatEnergyValue(it) } ?: "—"
+        }
+        ConsumerDisplayMode.ENERGY_WITH_PERIOD -> {
+            device.dailyEnergyWh?.let { "${formatEnergyValue(it)} / 24h" } ?: "—"
+        }
+    }
+
+    Text(
+        text = valueText,
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.powerConsumption
+    )
+}
+
+@Composable
+private fun getDeviceIconPainter(code: DeviceCode?): Painter {
+    return when (code) {
+        DeviceCode.SOLAR_PANEL, DeviceCode.SOLAR_PANEL_RESALE -> AppIcons.WbSunny
+        DeviceCode.OVEN -> AppIcons.Oven
+        DeviceCode.WASHING_MACHINE -> AppIcons.WashingMachine
+        DeviceCode.DISH_WASHER -> AppIcons.Dishwasher
+        DeviceCode.HEAT_PUMP, DeviceCode.PRO_HEAT_PUMP -> AppIcons.HeatPump
+        DeviceCode.POOL -> AppIcons.Pool
+        DeviceCode.ELECTRIC_CAR, DeviceCode.PRO_ELECTRIC_VEHICLE -> AppIcons.ElectricCar
+        DeviceCode.BATTERY, DeviceCode.BATTERY_CHARGE, DeviceCode.BATTERY_DISCHARGE -> AppIcons.Battery
+        DeviceCode.COMPUTER -> AppIcons.Computer
+        DeviceCode.LAPTOP -> AppIcons.Laptop
+        DeviceCode.TV -> AppIcons.Tv
+        DeviceCode.HI_FI -> AppIcons.Tv
+        DeviceCode.FRIDGE -> AppIcons.Fridge
+        DeviceCode.FREEZER -> AppIcons.Freezer
+        DeviceCode.COFFEE_MACHINE -> AppIcons.Coffee
+        DeviceCode.MICROWAVE_OVEN -> AppIcons.Microwave
+        DeviceCode.CLOTHES_DRYER -> AppIcons.ClothesDryer
+        DeviceCode.RADIATOR, DeviceCode.TOWEL_DRYER -> AppIcons.Radiator
+        DeviceCode.AIR_CONDITIONING, DeviceCode.PRO_AIR_CONDITIONING,
+        DeviceCode.PRO_ROOM_AIR_HANDLING_UNIT, DeviceCode.VMC -> AppIcons.Air
+        DeviceCode.BOILER, DeviceCode.PRO_BOILER -> AppIcons.Boiler
+        DeviceCode.HOT_WATER_TANK, DeviceCode.HOT_WATER_TANK_THERM,
+        DeviceCode.PRO_HOT_WATER_TANK -> AppIcons.WaterDrop
+        DeviceCode.LIGHT, DeviceCode.PRO_LIGHT -> AppIcons.Lightbulb
+        DeviceCode.GRID_METER, DeviceCode.WITHDRAWAL, DeviceCode.INJECTION -> AppIcons.Grid
+        DeviceCode.PRO_POWER_OUTLET, DeviceCode.HOUSEHOLD_APPLIANCES -> AppIcons.Outlet
+        DeviceCode.GLOBAL_CONSUMPTION, DeviceCode.INFO_ELECTRIC -> AppIcons.ElectricBolt
+        DeviceCode.PRO_COLD_UNIT, DeviceCode.PRO_COLD_ROOM -> AppIcons.Freezer
+        DeviceCode.PRO_COMPRESSOR -> AppIcons.Settings
+        DeviceCode.OTHER -> AppIcons.ElectricalServices
+        null -> AppIcons.ElectricalServices
+    }
+}
+
+private fun formatPowerValue(value: Double): String {
+    val absValue = abs(value)
+    return when {
+        absValue >= 1000 -> {
+            val kw = absValue / 1000
+            val rounded = (kw * 100).roundToInt() / 100.0
+            if (rounded == rounded.toLong().toDouble()) "${rounded.toLong()} kW"
+            else "$rounded kW"
+        }
+        else -> "${absValue.roundToInt()} W"
+    }
+}
+
+private fun formatEnergyValue(value: Double): String {
+    val absValue = abs(value)
+    return when {
+        absValue >= 1000 -> {
+            val kwh = absValue / 1000
+            val rounded = (kwh * 100).roundToInt() / 100.0
+            if (rounded == rounded.toLong().toDouble()) "${rounded.toLong()} kWh"
+            else "$rounded kWh"
+        }
+        else -> "${absValue.roundToInt()} Wh"
+    }
+}
+
+@Preview
+@Composable
+private fun TopConsumersCardSingleDevicePreview() {
+    ComwattTheme {
+        Surface {
+            TopConsumersCard(
+                devices = listOf(
+                    DeviceUiModel(
+                        id = 1,
+                        name = "Heat Pump",
+                        deviceCode = DeviceCode.HEAT_PUMP,
+                        isOnline = true,
+                        isProduction = false,
+                        instantPowerWatts = 2500.0,
+                        dailyEnergyWh = 45000.0,
+                        hasToggle = false,
+                        isToggleEnabled = false,
+                        category = DeviceCategoryGroup.CONSUMPTION
+                    )
+                ),
+                displayMode = ConsumerDisplayMode.INSTANT_POWER,
+                title = "Top Consumer Now",
+                modifier = Modifier.padding(16.dp)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun TopConsumersCardTwoDevicesPreview() {
+    ComwattTheme {
+        Surface {
+            TopConsumersCard(
+                devices = listOf(
+                    DeviceUiModel(
+                        id = 1,
+                        name = "Heat Pump",
+                        deviceCode = DeviceCode.HEAT_PUMP,
+                        isOnline = true,
+                        isProduction = false,
+                        instantPowerWatts = 2500.0,
+                        dailyEnergyWh = 45000.0,
+                        hasToggle = false,
+                        isToggleEnabled = false,
+                        category = DeviceCategoryGroup.CONSUMPTION
+                    ),
+                    DeviceUiModel(
+                        id = 2,
+                        name = "Electric Car Charger",
+                        deviceCode = DeviceCode.ELECTRIC_CAR,
+                        isOnline = true,
+                        isProduction = false,
+                        instantPowerWatts = 1800.0,
+                        dailyEnergyWh = 22000.0,
+                        hasToggle = false,
+                        isToggleEnabled = false,
+                        category = DeviceCategoryGroup.CONSUMPTION
+                    )
+                ),
+                displayMode = ConsumerDisplayMode.INSTANT_POWER,
+                title = "Top Consumers Now",
+                modifier = Modifier.padding(16.dp)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun TopConsumersCardDailyEnergyPreview() {
+    ComwattTheme {
+        Surface {
+            TopConsumersCard(
+                devices = listOf(
+                    DeviceUiModel(
+                        id = 1,
+                        name = "Washing Machine",
+                        deviceCode = DeviceCode.WASHING_MACHINE,
+                        isOnline = true,
+                        isProduction = false,
+                        instantPowerWatts = 500.0,
+                        dailyEnergyWh = 3500.0,
+                        hasToggle = true,
+                        isToggleEnabled = true,
+                        category = DeviceCategoryGroup.CONSUMPTION
+                    ),
+                    DeviceUiModel(
+                        id = 2,
+                        name = "Dishwasher",
+                        deviceCode = DeviceCode.DISH_WASHER,
+                        isOnline = true,
+                        isProduction = false,
+                        instantPowerWatts = 450.0,
+                        dailyEnergyWh = 2800.0,
+                        hasToggle = false,
+                        isToggleEnabled = false,
+                        category = DeviceCategoryGroup.CONSUMPTION
+                    )
+                ),
+                displayMode = ConsumerDisplayMode.ENERGY_WITH_PERIOD,
+                title = "Biggest Consumers Today",
+                modifier = Modifier.padding(16.dp)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun TopConsumersCardEmptyPreview() {
+    ComwattTheme {
+        Surface {
+            TopConsumersCard(
+                devices = emptyList(),
+                displayMode = ConsumerDisplayMode.INSTANT_POWER,
+                title = "Top Consumers Now",
+                modifier = Modifier.padding(16.dp)
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreen.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreen.kt
@@ -102,6 +102,7 @@ import comwatt.shared.generated.resources.statistics_card_title_custom
 import comwatt.shared.generated.resources.statistics_card_title_hourly
 import comwatt.shared.generated.resources.statistics_card_title_sixhourly
 import comwatt.shared.generated.resources.statistics_card_title_weekly
+import comwatt.shared.generated.resources.top_consumers_title
 import comwatt.shared.generated.resources.week_range_selected_time_n_weeks_ago
 import comwatt.shared.generated.resources.week_range_selected_time_one_week_ago
 import comwatt.shared.generated.resources.week_range_selected_time_past_seven_days
@@ -116,12 +117,15 @@ import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 import net.thevenot.comwatt.DataRepository
 import net.thevenot.comwatt.domain.FetchTimeSeriesUseCase
+import net.thevenot.comwatt.domain.FetchTopConsumersUseCase
 import net.thevenot.comwatt.domain.model.ChartTimeSeries
 import net.thevenot.comwatt.domain.model.TimeSeries
 import net.thevenot.comwatt.domain.model.TimeSeriesTitle
 import net.thevenot.comwatt.domain.model.TimeSeriesType
 import net.thevenot.comwatt.ui.common.CenteredTitleWithIcon
+import net.thevenot.comwatt.ui.common.ConsumerDisplayMode
 import net.thevenot.comwatt.ui.common.LoadingView
+import net.thevenot.comwatt.ui.common.TopConsumersCard
 import net.thevenot.comwatt.ui.dashboard.types.DashboardTimeUnit
 import net.thevenot.comwatt.ui.home.statistics.StatisticsCard
 import net.thevenot.comwatt.ui.nav.NestedAppScaffold
@@ -153,7 +157,11 @@ fun DashboardScreen(
     snackbarHostState: SnackbarHostState,
     dataRepository: DataRepository,
     viewModel: DashboardViewModel = viewModel {
-        DashboardViewModel(FetchTimeSeriesUseCase(dataRepository), dataRepository)
+        DashboardViewModel(
+            FetchTimeSeriesUseCase(dataRepository),
+            dataRepository,
+            FetchTopConsumersUseCase(dataRepository)
+        )
     }
 ) {
     DashboardScreenContent(navController, dataRepository, snackbarHostState, viewModel)
@@ -165,7 +173,11 @@ fun DashboardScreenContent(
     dataRepository: DataRepository,
     snackbarHostState: SnackbarHostState,
     viewModel: DashboardViewModel = viewModel {
-        DashboardViewModel(FetchTimeSeriesUseCase(dataRepository), dataRepository)
+        DashboardViewModel(
+            FetchTimeSeriesUseCase(dataRepository),
+            dataRepository,
+            FetchTopConsumersUseCase(dataRepository)
+        )
     }
 ) {
     LifecycleResumeEffect(Unit) {
@@ -259,6 +271,17 @@ fun DashboardScreenContent(
                                 totalsLabel = buildRangeTotalsLabel(uiState),
                                 modifier = Modifier.fillMaxWidth(),
                                 title = statsTitle
+                            )
+                        }
+                    }
+
+                    if (uiState.topConsumers.isNotEmpty()) {
+                        item(key = "top_consumers_card") {
+                            TopConsumersCard(
+                                devices = uiState.topConsumers,
+                                displayMode = ConsumerDisplayMode.ENERGY,
+                                title = stringResource(Res.string.top_consumers_title),
+                                modifier = Modifier.fillMaxWidth()
                             )
                         }
                     }

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreen.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ButtonGroupDefaults
 import androidx.compose.material3.Card
+import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -277,12 +278,14 @@ fun DashboardScreenContent(
 
                     if (uiState.topConsumers.isNotEmpty()) {
                         item(key = "top_consumers_card") {
-                            TopConsumersCard(
-                                devices = uiState.topConsumers,
-                                displayMode = ConsumerDisplayMode.ENERGY,
-                                title = stringResource(Res.string.top_consumers_title),
-                                modifier = Modifier.fillMaxWidth()
-                            )
+                            ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+                                TopConsumersCard(
+                                    devices = uiState.topConsumers,
+                                    displayMode = ConsumerDisplayMode.ENERGY,
+                                    title = stringResource(Res.string.top_consumers_title),
+                                    modifier = Modifier.fillMaxWidth().padding(AppTheme.dimens.paddingNormal)
+                                )
+                            }
                         }
                     }
 

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreen.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreen.kt
@@ -104,6 +104,11 @@ import comwatt.shared.generated.resources.statistics_card_title_hourly
 import comwatt.shared.generated.resources.statistics_card_title_sixhourly
 import comwatt.shared.generated.resources.statistics_card_title_weekly
 import comwatt.shared.generated.resources.top_consumers_title
+import comwatt.shared.generated.resources.top_consumers_past_hour
+import comwatt.shared.generated.resources.top_consumers_past_6h
+import comwatt.shared.generated.resources.top_consumers_today
+import comwatt.shared.generated.resources.top_consumers_this_week
+import comwatt.shared.generated.resources.top_consumers_custom
 import comwatt.shared.generated.resources.week_range_selected_time_n_weeks_ago
 import comwatt.shared.generated.resources.week_range_selected_time_one_week_ago
 import comwatt.shared.generated.resources.week_range_selected_time_past_seven_days
@@ -267,12 +272,20 @@ fun DashboardScreenContent(
                                 DashboardTimeUnit.WEEK -> stringResource(Res.string.statistics_card_title_weekly)
                                 DashboardTimeUnit.CUSTOM -> stringResource(Res.string.statistics_card_title_custom)
                             }
+                            val topConsumersTitle = when (uiState.selectedTimeUnit) {
+                                DashboardTimeUnit.HOUR -> stringResource(Res.string.top_consumers_past_hour)
+                                DashboardTimeUnit.SIXHOUR -> stringResource(Res.string.top_consumers_past_6h)
+                                DashboardTimeUnit.DAY -> stringResource(Res.string.top_consumers_today)
+                                DashboardTimeUnit.WEEK -> stringResource(Res.string.top_consumers_this_week)
+                                DashboardTimeUnit.CUSTOM -> stringResource(Res.string.top_consumers_custom)
+                            }
                             StatisticsCard(
                                 siteDailyData = stats,
                                 totalsLabel = buildRangeTotalsLabel(uiState),
                                 modifier = Modifier.fillMaxWidth(),
                                 title = statsTitle,
-                                topConsumers = uiState.topConsumers
+                                topConsumers = uiState.topConsumers,
+                                topConsumersTitle = topConsumersTitle
                             )
                         }
                     }

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreen.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreen.kt
@@ -104,11 +104,6 @@ import comwatt.shared.generated.resources.statistics_card_title_hourly
 import comwatt.shared.generated.resources.statistics_card_title_sixhourly
 import comwatt.shared.generated.resources.statistics_card_title_weekly
 import comwatt.shared.generated.resources.top_consumers_title
-import comwatt.shared.generated.resources.top_consumers_past_hour
-import comwatt.shared.generated.resources.top_consumers_past_6h
-import comwatt.shared.generated.resources.top_consumers_today
-import comwatt.shared.generated.resources.top_consumers_this_week
-import comwatt.shared.generated.resources.top_consumers_custom
 import comwatt.shared.generated.resources.week_range_selected_time_n_weeks_ago
 import comwatt.shared.generated.resources.week_range_selected_time_one_week_ago
 import comwatt.shared.generated.resources.week_range_selected_time_past_seven_days
@@ -272,20 +267,13 @@ fun DashboardScreenContent(
                                 DashboardTimeUnit.WEEK -> stringResource(Res.string.statistics_card_title_weekly)
                                 DashboardTimeUnit.CUSTOM -> stringResource(Res.string.statistics_card_title_custom)
                             }
-                            val topConsumersTitle = when (uiState.selectedTimeUnit) {
-                                DashboardTimeUnit.HOUR -> stringResource(Res.string.top_consumers_past_hour)
-                                DashboardTimeUnit.SIXHOUR -> stringResource(Res.string.top_consumers_past_6h)
-                                DashboardTimeUnit.DAY -> stringResource(Res.string.top_consumers_today)
-                                DashboardTimeUnit.WEEK -> stringResource(Res.string.top_consumers_this_week)
-                                DashboardTimeUnit.CUSTOM -> stringResource(Res.string.top_consumers_custom)
-                            }
                             StatisticsCard(
                                 siteDailyData = stats,
                                 totalsLabel = buildRangeTotalsLabel(uiState),
                                 modifier = Modifier.fillMaxWidth(),
                                 title = statsTitle,
                                 topConsumers = uiState.topConsumers,
-                                topConsumersTitle = topConsumersTitle
+                                topConsumersTitle = stringResource(Res.string.top_consumers_title)
                             )
                         }
                     }

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreen.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreen.kt
@@ -271,21 +271,9 @@ fun DashboardScreenContent(
                                 siteDailyData = stats,
                                 totalsLabel = buildRangeTotalsLabel(uiState),
                                 modifier = Modifier.fillMaxWidth(),
-                                title = statsTitle
+                                title = statsTitle,
+                                topConsumers = uiState.topConsumers
                             )
-                        }
-                    }
-
-                    if (uiState.topConsumers.isNotEmpty()) {
-                        item(key = "top_consumers_card") {
-                            ElevatedCard(modifier = Modifier.fillMaxWidth()) {
-                                TopConsumersCard(
-                                    devices = uiState.topConsumers,
-                                    displayMode = ConsumerDisplayMode.ENERGY,
-                                    title = stringResource(Res.string.top_consumers_title),
-                                    modifier = Modifier.fillMaxWidth().padding(AppTheme.dimens.paddingNormal)
-                                )
-                            }
                         }
                     }
 

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreenState.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreenState.kt
@@ -8,6 +8,7 @@ import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
+import net.thevenot.comwatt.domain.model.DeviceUiModel
 import net.thevenot.comwatt.domain.model.SiteDailyData
 import net.thevenot.comwatt.ui.dashboard.types.DashboardTimeUnit
 import kotlin.time.Clock
@@ -21,7 +22,8 @@ data class DashboardScreenState(
     val callCount: Int = 0,
     val selectedTimeRange: SelectedTimeRange = SelectedTimeRange(),
     val rangeStats: SiteDailyData? = null,
-    val expandedCards: Set<String> = emptySet()
+    val expandedCards: Set<String> = emptySet(),
+    val topConsumers: List<DeviceUiModel> = emptyList()
 )
 
 data class SelectedTimeRange(

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardViewModel.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardViewModel.kt
@@ -20,8 +20,10 @@ import kotlinx.datetime.toInstant
 import net.thevenot.comwatt.DataRepository
 import net.thevenot.comwatt.domain.FetchParameters
 import net.thevenot.comwatt.domain.FetchTimeSeriesUseCase
+import net.thevenot.comwatt.domain.FetchTopConsumersUseCase
 import net.thevenot.comwatt.domain.exception.DomainError
 import net.thevenot.comwatt.domain.model.ChartTimeSeries
+import net.thevenot.comwatt.domain.model.ConsumerMetric
 import net.thevenot.comwatt.domain.model.TimeUnit
 import net.thevenot.comwatt.domain.utils.computeSiteStats
 import net.thevenot.comwatt.model.type.AggregationLevel
@@ -33,7 +35,8 @@ import kotlin.time.Instant
 
 class DashboardViewModel(
     private val fetchTimeSeriesUseCase: FetchTimeSeriesUseCase,
-    private val dataRepository: DataRepository
+    private val dataRepository: DataRepository,
+    private val fetchTopConsumersUseCase: FetchTopConsumersUseCase
 ): ViewModel() {
     private var autoRefreshJob: Job? = null
 
@@ -54,6 +57,9 @@ class DashboardViewModel(
             }
             launch {
                 refreshRangeStats()
+            }
+            launch {
+                fetchTopConsumersForCurrentRange()
             }
         }
     }
@@ -133,6 +139,9 @@ class DashboardViewModel(
             }
             launch {
                 refreshRangeStats()
+            }
+            launch {
+                fetchTopConsumersForCurrentRange()
             }
         }
     }
@@ -337,6 +346,30 @@ class DashboardViewModel(
             DashboardTimeUnit.WEEK -> range.week.start to range.week.end
             DashboardTimeUnit.CUSTOM -> range.custom.start to range.custom.end
         }
+    }
+
+    private suspend fun fetchTopConsumersForCurrentRange() {
+        val (start, end) = getRangeBounds(
+            _uiState.value.selectedTimeUnit,
+            _uiState.value.selectedTimeRange
+        )
+
+        val startTime = start.toInstant(TimeZone.currentSystemDefault())
+        val endTime = end.toInstant(TimeZone.currentSystemDefault())
+
+        fetchTopConsumersUseCase.execute(
+            limit = 2,
+            sortBy = ConsumerMetric.CUSTOM_RANGE,
+            startTime = startTime,
+            endTime = endTime
+        ).fold(
+            ifLeft = { error ->
+                Logger.e(TAG) { "Failed to fetch top consumers: $error" }
+            },
+            ifRight = { consumers ->
+                _uiState.update { it.copy(topConsumers = consumers) }
+            }
+        )
     }
 
     fun toggleCardExpansion(chartName: String) {

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/FullscreenChartScreen.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/FullscreenChartScreen.kt
@@ -53,6 +53,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import net.thevenot.comwatt.DataRepository
 import net.thevenot.comwatt.domain.FetchTimeSeriesUseCase
+import net.thevenot.comwatt.domain.FetchTopConsumersUseCase
 import net.thevenot.comwatt.domain.model.TimeSeries
 import net.thevenot.comwatt.domain.model.TimeSeriesType
 import net.thevenot.comwatt.ui.common.LoadingView
@@ -78,7 +79,11 @@ fun FullscreenChartScreen(
     dataRepository: DataRepository,
     chartIndex: Int,
     viewModel: DashboardViewModel = viewModel {
-        DashboardViewModel(FetchTimeSeriesUseCase(dataRepository), dataRepository)
+        DashboardViewModel(
+            FetchTimeSeriesUseCase(dataRepository),
+            dataRepository,
+            FetchTopConsumersUseCase(dataRepository)
+        )
     }
 ) {
     // Lock to landscape when entering, unlock when leaving

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeScreen.kt
@@ -156,6 +156,7 @@ private fun HomeScreenContent(
             StatisticsCard(
                 siteDailyData = uiState.siteDailyData,
                 totalsLabel = stringResource(Res.string.statistics_card_today_total),
+                topConsumers = uiState.topDailyConsumers,
                 modifier = Modifier,
                 title = stringResource(Res.string.statistics_card_title)
             )

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeScreen.kt
@@ -153,6 +153,19 @@ private fun HomeScreenContent(
             Spacer(modifier = Modifier.height(AppTheme.dimens.paddingSmall))
 
             RealTimeConsumptionSection(uiState = uiState)
+
+            // Top realtime consumers card
+            if (uiState.topRealtimeConsumers.isNotEmpty()) {
+                ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+                    TopConsumersCard(
+                        devices = uiState.topRealtimeConsumers,
+                        displayMode = ConsumerDisplayMode.INSTANT_POWER,
+                        title = stringResource(Res.string.top_consumers_realtime_title),
+                        modifier = Modifier.fillMaxWidth().padding(AppTheme.dimens.paddingNormal)
+                    )
+                }
+            }
+
             StatisticsCard(
                 siteDailyData = uiState.siteDailyData,
                 totalsLabel = stringResource(Res.string.statistics_card_today_total),
@@ -206,16 +219,6 @@ private fun RealTimeConsumptionSection(
                 )
 
                 PowerFlowBalance(uiState = uiState)
-
-                // Add top consumers
-                if (uiState.topRealtimeConsumers.isNotEmpty()) {
-                    TopConsumersCard(
-                        devices = uiState.topRealtimeConsumers,
-                        displayMode = ConsumerDisplayMode.INSTANT_POWER,
-                        title = stringResource(Res.string.top_consumers_realtime_title),
-                        modifier = Modifier.fillMaxWidth().padding(top = AppTheme.dimens.paddingSmall)
-                    )
-                }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeScreen.kt
@@ -38,17 +38,21 @@ import comwatt.shared.generated.resources.last_data_refresh_time
 import comwatt.shared.generated.resources.last_data_refresh_time_zero
 import comwatt.shared.generated.resources.statistics_card_title
 import comwatt.shared.generated.resources.statistics_card_today_total
+import comwatt.shared.generated.resources.top_consumers_realtime_title
 import kotlinx.coroutines.delay
 import net.thevenot.comwatt.DataRepository
 import net.thevenot.comwatt.domain.FetchCurrentSiteUseCase
 import net.thevenot.comwatt.domain.FetchElectricityPriceUseCase
 import net.thevenot.comwatt.domain.FetchSiteDailyDataUseCase
 import net.thevenot.comwatt.domain.FetchSiteRealtimeDataUseCase
+import net.thevenot.comwatt.domain.FetchTopConsumersUseCase
 import net.thevenot.comwatt.domain.FetchWeatherUseCase
 import net.thevenot.comwatt.domain.model.SiteDailyData
 import net.thevenot.comwatt.domain.model.SiteRealtimeData
 import net.thevenot.comwatt.ui.common.CenteredTitleWithIcon
+import net.thevenot.comwatt.ui.common.ConsumerDisplayMode
 import net.thevenot.comwatt.ui.common.LoadingView
+import net.thevenot.comwatt.ui.common.TopConsumersCard
 import net.thevenot.comwatt.ui.home.gauge.PowerFlowBalance
 import net.thevenot.comwatt.ui.home.house.HouseScreen
 import net.thevenot.comwatt.ui.home.statistics.StatisticsCard
@@ -72,7 +76,8 @@ fun HomeScreen(
             fetchSiteDailyDataUseCase = FetchSiteDailyDataUseCase(dataRepository),
             fetchWeatherUseCase = FetchWeatherUseCase(dataRepository),
             fetchCurrentSiteUseCase = FetchCurrentSiteUseCase(dataRepository),
-            fetchElectricityPriceUseCase = FetchElectricityPriceUseCase(dataRepository)
+            fetchElectricityPriceUseCase = FetchElectricityPriceUseCase(dataRepository),
+            fetchTopConsumersUseCase = FetchTopConsumersUseCase(dataRepository)
         )
     }
 ) {
@@ -200,6 +205,16 @@ private fun RealTimeConsumptionSection(
                 )
 
                 PowerFlowBalance(uiState = uiState)
+
+                // Add top consumers
+                if (uiState.topRealtimeConsumers.isNotEmpty()) {
+                    TopConsumersCard(
+                        devices = uiState.topRealtimeConsumers,
+                        displayMode = ConsumerDisplayMode.INSTANT_POWER,
+                        title = stringResource(Res.string.top_consumers_realtime_title),
+                        modifier = Modifier.fillMaxWidth().padding(top = AppTheme.dimens.paddingSmall)
+                    )
+                }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeScreen.kt
@@ -154,18 +154,6 @@ private fun HomeScreenContent(
 
             RealTimeConsumptionSection(uiState = uiState)
 
-            // Top realtime consumers card
-            if (uiState.topRealtimeConsumers.isNotEmpty()) {
-                ElevatedCard(modifier = Modifier.fillMaxWidth()) {
-                    TopConsumersCard(
-                        devices = uiState.topRealtimeConsumers,
-                        displayMode = ConsumerDisplayMode.INSTANT_POWER,
-                        title = stringResource(Res.string.top_consumers_realtime_title),
-                        modifier = Modifier.fillMaxWidth().padding(AppTheme.dimens.paddingNormal)
-                    )
-                }
-            }
-
             StatisticsCard(
                 siteDailyData = uiState.siteDailyData,
                 totalsLabel = stringResource(Res.string.statistics_card_today_total),
@@ -219,6 +207,16 @@ private fun RealTimeConsumptionSection(
                 )
 
                 PowerFlowBalance(uiState = uiState)
+            }
+
+            // Top realtime consumers - added back inside with extra spacing
+            if (uiState.topRealtimeConsumers.isNotEmpty()) {
+                TopConsumersCard(
+                    devices = uiState.topRealtimeConsumers,
+                    displayMode = ConsumerDisplayMode.INSTANT_POWER,
+                    title = stringResource(Res.string.top_consumers_realtime_title),
+                    modifier = Modifier.fillMaxWidth().padding(top = AppTheme.dimens.paddingNormal)
+                )
             }
         }
     }

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeScreenState.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeScreenState.kt
@@ -21,4 +21,5 @@ data class HomeScreenState(
     val weatherForecast: WeatherForecast? = null,
     val electricityPrice: ElectricityPrice? = null,
     val topRealtimeConsumers: List<DeviceUiModel> = emptyList(),
+    val topDailyConsumers: List<DeviceUiModel> = emptyList(),
 )

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeScreenState.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeScreenState.kt
@@ -1,5 +1,6 @@
 package net.thevenot.comwatt.ui.home
 
+import net.thevenot.comwatt.domain.model.DeviceUiModel
 import net.thevenot.comwatt.domain.model.ElectricityPrice
 import net.thevenot.comwatt.domain.model.SiteDailyData
 import net.thevenot.comwatt.domain.model.SiteRealtimeData
@@ -19,4 +20,5 @@ data class HomeScreenState(
     val siteName: String? = null,
     val weatherForecast: WeatherForecast? = null,
     val electricityPrice: ElectricityPrice? = null,
+    val topRealtimeConsumers: List<DeviceUiModel> = emptyList(),
 )

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeViewModel.kt
@@ -196,6 +196,19 @@ class HomeViewModel(
                 }
             )
 
+            // Fetch top daily consumers
+            fetchTopConsumersUseCase.execute(
+                limit = 2,
+                sortBy = ConsumerMetric.DAILY_ENERGY
+            ).fold(
+                ifLeft = { error ->
+                    Logger.e(TAG) { "Failed to fetch top daily consumers: $error" }
+                },
+                ifRight = { consumers ->
+                    _uiState.update { it.copy(topDailyConsumers = consumers) }
+                }
+            )
+
             _uiState.update { it.copy(isRefreshing = false) }
         }
     }

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeViewModel.kt
@@ -19,8 +19,10 @@ import net.thevenot.comwatt.domain.FetchCurrentSiteUseCase
 import net.thevenot.comwatt.domain.FetchElectricityPriceUseCase
 import net.thevenot.comwatt.domain.FetchSiteDailyDataUseCase
 import net.thevenot.comwatt.domain.FetchSiteRealtimeDataUseCase
+import net.thevenot.comwatt.domain.FetchTopConsumersUseCase
 import net.thevenot.comwatt.domain.FetchWeatherUseCase
 import net.thevenot.comwatt.domain.exception.DomainError
+import net.thevenot.comwatt.domain.model.ConsumerMetric
 import kotlin.time.Clock
 
 
@@ -29,7 +31,8 @@ class HomeViewModel(
     private val fetchSiteDailyDataUseCase: FetchSiteDailyDataUseCase,
     private val fetchWeatherUseCase: FetchWeatherUseCase,
     private val fetchCurrentSiteUseCase: FetchCurrentSiteUseCase,
-    private val fetchElectricityPriceUseCase: FetchElectricityPriceUseCase
+    private val fetchElectricityPriceUseCase: FetchElectricityPriceUseCase,
+    private val fetchTopConsumersUseCase: FetchTopConsumersUseCase
 ) : ViewModel() {
     private var autoRefreshJob: Job? = null
 
@@ -179,6 +182,19 @@ class HomeViewModel(
                     state.copy(electricityPrice = price)
                 }
             }
+
+            // Fetch top realtime consumers
+            fetchTopConsumersUseCase.execute(
+                limit = 2,
+                sortBy = ConsumerMetric.INSTANT_POWER
+            ).fold(
+                ifLeft = { error ->
+                    Logger.e(TAG) { "Failed to fetch top realtime consumers: $error" }
+                },
+                ifRight = { consumers ->
+                    _uiState.update { it.copy(topRealtimeConsumers = consumers) }
+                }
+            )
 
             _uiState.update { it.copy(isRefreshing = false) }
         }

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeViewModel.kt
@@ -132,6 +132,34 @@ class HomeViewModel(
                     }
                 }
             }
+            // Fetch top consumers on initial load
+            launch {
+                // Fetch top realtime consumers
+                fetchTopConsumersUseCase.execute(
+                    limit = 2,
+                    sortBy = ConsumerMetric.INSTANT_POWER
+                ).fold(
+                    ifLeft = { error ->
+                        Logger.e(TAG) { "Failed to fetch top realtime consumers: $error" }
+                    },
+                    ifRight = { consumers ->
+                        _uiState.update { it.copy(topRealtimeConsumers = consumers) }
+                    }
+                )
+
+                // Fetch top daily consumers
+                fetchTopConsumersUseCase.execute(
+                    limit = 2,
+                    sortBy = ConsumerMetric.DAILY_ENERGY
+                ).fold(
+                    ifLeft = { error ->
+                        Logger.e(TAG) { "Failed to fetch top daily consumers: $error" }
+                    },
+                    ifRight = { consumers ->
+                        _uiState.update { it.copy(topDailyConsumers = consumers) }
+                    }
+                )
+            }
         }
     }
 

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/statistics/StatisticsCard.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/statistics/StatisticsCard.kt
@@ -78,7 +78,8 @@ fun StatisticsCard(
     totalsLabel: String,
     modifier: Modifier = Modifier,
     title: String? = null,
-    topConsumers: List<DeviceUiModel> = emptyList()
+    topConsumers: List<DeviceUiModel> = emptyList(),
+    topConsumersTitle: String? = null
 ) {
     siteDailyData?.let { siteData ->
         ElevatedCard(
@@ -134,7 +135,7 @@ fun StatisticsCard(
                     TopConsumersCard(
                         devices = topConsumers,
                         displayMode = ConsumerDisplayMode.ENERGY,
-                        title = stringResource(Res.string.top_consumers_daily_title),
+                        title = topConsumersTitle ?: stringResource(Res.string.top_consumers_daily_title),
                         modifier = Modifier.fillMaxWidth()
                     )
                 }

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/statistics/StatisticsCard.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/statistics/StatisticsCard.kt
@@ -133,7 +133,7 @@ fun StatisticsCard(
                 if (topConsumers.isNotEmpty()) {
                     TopConsumersCard(
                         devices = topConsumers,
-                        displayMode = ConsumerDisplayMode.ENERGY_WITH_PERIOD,
+                        displayMode = ConsumerDisplayMode.ENERGY,
                         title = stringResource(Res.string.top_consumers_daily_title),
                         modifier = Modifier.fillMaxWidth()
                     )

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/statistics/StatisticsCard.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/statistics/StatisticsCard.kt
@@ -55,9 +55,13 @@ import comwatt.shared.generated.resources.statistics_card_self_consumption_na
 import comwatt.shared.generated.resources.statistics_card_title
 import comwatt.shared.generated.resources.statistics_self_consumption_rate
 import comwatt.shared.generated.resources.statistics_self_consumption_tooltip
+import comwatt.shared.generated.resources.top_consumers_daily_title
 
 import kotlinx.coroutines.launch
+import net.thevenot.comwatt.domain.model.DeviceUiModel
 import net.thevenot.comwatt.domain.model.SiteDailyData
+import net.thevenot.comwatt.ui.common.ConsumerDisplayMode
+import net.thevenot.comwatt.ui.common.TopConsumersCard
 import net.thevenot.comwatt.ui.theme.AppTheme
 import net.thevenot.comwatt.ui.theme.ComwattTheme
 import net.thevenot.comwatt.ui.theme.icons.AppIcons
@@ -74,6 +78,7 @@ fun StatisticsCard(
     totalsLabel: String,
     modifier: Modifier = Modifier,
     title: String? = null,
+    topConsumers: List<DeviceUiModel> = emptyList()
 ) {
     siteDailyData?.let { siteData ->
         ElevatedCard(
@@ -124,6 +129,15 @@ fun StatisticsCard(
                 }
 
                 DailyTotalsSection(siteData, totalsLabel)
+
+                if (topConsumers.isNotEmpty()) {
+                    TopConsumersCard(
+                        devices = topConsumers,
+                        displayMode = ConsumerDisplayMode.ENERGY_WITH_PERIOD,
+                        title = stringResource(Res.string.top_consumers_daily_title),
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
             }
         }
     }

--- a/shared/src/commonTest/kotlin/net/thevenot/comwatt/domain/FetchTopConsumersUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/net/thevenot/comwatt/domain/FetchTopConsumersUseCaseTest.kt
@@ -1,0 +1,188 @@
+package net.thevenot.comwatt.domain
+
+import kotlinx.coroutines.test.runTest
+import net.thevenot.comwatt.domain.model.ConsumerMetric
+import net.thevenot.comwatt.domain.model.DeviceCategoryGroup
+import net.thevenot.comwatt.domain.model.DeviceUiModel
+import net.thevenot.comwatt.model.DeviceCode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class FetchTopConsumersUseCaseTest {
+
+    private fun createTestDevices() = listOf(
+        DeviceUiModel(
+            id = 1,
+            name = "High Power Device",
+            deviceCode = DeviceCode.HEAT_PUMP,
+            isOnline = true,
+            isProduction = false,
+            instantPowerWatts = 1000.0,
+            dailyEnergyWh = 15000.0,
+            hasToggle = false,
+            isToggleEnabled = false,
+            category = DeviceCategoryGroup.CONSUMPTION
+        ),
+        DeviceUiModel(
+            id = 2,
+            name = "Medium Power Device",
+            deviceCode = DeviceCode.WASHING_MACHINE,
+            isOnline = true,
+            isProduction = false,
+            instantPowerWatts = 500.0,
+            dailyEnergyWh = 2000.0,
+            hasToggle = true,
+            isToggleEnabled = true,
+            category = DeviceCategoryGroup.CONSUMPTION
+        ),
+        DeviceUiModel(
+            id = 3,
+            name = "Low Power Device",
+            deviceCode = DeviceCode.TV,
+            isOnline = true,
+            isProduction = false,
+            instantPowerWatts = 50.0,
+            dailyEnergyWh = 500.0,
+            hasToggle = false,
+            isToggleEnabled = false,
+            category = DeviceCategoryGroup.CONSUMPTION
+        ),
+        DeviceUiModel(
+            id = 4,
+            name = "Production Device",
+            deviceCode = DeviceCode.SOLAR_PANEL,
+            isOnline = true,
+            isProduction = true,
+            instantPowerWatts = 2000.0,
+            dailyEnergyWh = 30000.0,
+            hasToggle = false,
+            isToggleEnabled = false,
+            category = DeviceCategoryGroup.PRODUCTION
+        ),
+        DeviceUiModel(
+            id = 5,
+            name = "Offline Device",
+            deviceCode = DeviceCode.ELECTRIC_CAR,
+            isOnline = false,
+            isProduction = false,
+            instantPowerWatts = null,
+            dailyEnergyWh = null,
+            hasToggle = false,
+            isToggleEnabled = false,
+            category = DeviceCategoryGroup.CONSUMPTION
+        )
+    )
+
+    @Test
+    fun `filterAndSort with INSTANT_POWER sorts devices by instantPowerWatts descending`() = runTest {
+        val devices = createTestDevices()
+
+        val result = FetchTopConsumersUseCase.filterAndSort(
+            devices = devices,
+            limit = 2,
+            sortBy = ConsumerMetric.INSTANT_POWER
+        )
+
+        assertEquals(2, result.size)
+        assertEquals("High Power Device", result[0].name)
+        assertEquals(1000.0, result[0].instantPowerWatts)
+        assertEquals("Medium Power Device", result[1].name)
+        assertEquals(500.0, result[1].instantPowerWatts)
+    }
+
+    @Test
+    fun `filterAndSort with DAILY_ENERGY sorts devices by dailyEnergyWh descending`() = runTest {
+        val devices = createTestDevices()
+
+        val result = FetchTopConsumersUseCase.filterAndSort(
+            devices = devices,
+            limit = 2,
+            sortBy = ConsumerMetric.DAILY_ENERGY
+        )
+
+        assertEquals(2, result.size)
+        assertEquals("High Power Device", result[0].name)
+        assertEquals(15000.0, result[0].dailyEnergyWh)
+        assertEquals("Medium Power Device", result[1].name)
+        assertEquals(2000.0, result[1].dailyEnergyWh)
+    }
+
+    @Test
+    fun `filterAndSort excludes production devices`() = runTest {
+        val devices = createTestDevices()
+
+        val result = FetchTopConsumersUseCase.filterAndSort(
+            devices = devices,
+            limit = 10,
+            sortBy = ConsumerMetric.INSTANT_POWER
+        )
+
+        assertTrue(result.none { it.isProduction })
+    }
+
+    @Test
+    fun `filterAndSort excludes offline devices`() = runTest {
+        val devices = createTestDevices()
+
+        val result = FetchTopConsumersUseCase.filterAndSort(
+            devices = devices,
+            limit = 10,
+            sortBy = ConsumerMetric.INSTANT_POWER
+        )
+
+        assertTrue(result.none { !it.isOnline })
+    }
+
+    @Test
+    fun `filterAndSort returns empty list when all devices are filtered out`() = runTest {
+        val devices = listOf(
+            DeviceUiModel(
+                id = 1,
+                name = "Production Device",
+                deviceCode = DeviceCode.SOLAR_PANEL,
+                isOnline = true,
+                isProduction = true,
+                instantPowerWatts = 2000.0,
+                dailyEnergyWh = 30000.0,
+                hasToggle = false,
+                isToggleEnabled = false,
+                category = DeviceCategoryGroup.PRODUCTION
+            )
+        )
+
+        val result = FetchTopConsumersUseCase.filterAndSort(
+            devices = devices,
+            limit = 2,
+            sortBy = ConsumerMetric.INSTANT_POWER
+        )
+
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun `filterAndSort returns fewer devices when limit exceeds available devices`() = runTest {
+        val devices = listOf(
+            DeviceUiModel(
+                id = 1,
+                name = "Device 1",
+                deviceCode = DeviceCode.TV,
+                isOnline = true,
+                isProduction = false,
+                instantPowerWatts = 100.0,
+                dailyEnergyWh = 1000.0,
+                hasToggle = false,
+                isToggleEnabled = false,
+                category = DeviceCategoryGroup.CONSUMPTION
+            )
+        )
+
+        val result = FetchTopConsumersUseCase.filterAndSort(
+            devices = devices,
+            limit = 5,
+            sortBy = ConsumerMetric.INSTANT_POWER
+        )
+
+        assertEquals(1, result.size)
+    }
+}


### PR DESCRIPTION
 ## Summary

  Adds a new "biggest consumer" component that displays the top 1-2 energy consuming devices across different contexts:

  - **Home screen (realtime card)**: Shows devices consuming most power right now (instant power in W/kW)
  - **Home screen (statistics card)**: Shows devices that consumed most energy today (total kWh)
  - **Dashboard (statistics card)**: Shows devices consuming most in the selected time range (total kWh)

  The component automatically:
  - Loads on initial screen open (not just on refresh)
  - Filters out production and offline devices
  - Sorts by appropriate metric (instant power vs daily energy vs custom range)
  - Displays formatted values with proper units
  - Shows contextual titles based on location

  ## Changes

  ### New Components
  - `ConsumerMetric` enum - Defines sorting metrics (instant power, daily energy, custom range)
  - `ConsumerDisplayMode` enum - Defines display formatting modes
  - `FetchTopConsumersUseCase` - Domain use case to fetch and sort top consuming devices
  - `TopConsumersCard` - Reusable UI component to display top consumers
  - Comprehensive unit tests (6 tests, all passing)

  ### Integrations
  - **HomeScreen**: Added top consumers to realtime card and statistics card
  - **DashboardScreen**: Added top consumers to statistics card
  - **Localized strings**: Added 3 new string resources

  ### Bug Fixes
  - Fixed initial loading (consumers now load on first screen open)
  - Improved visual layout (proper spacing and card integration)
  - Simplified titles (removed confusing dynamic logic on dashboard)

  ## Test Plan

  - [x] Unit tests pass (6 tests for FetchTopConsumersUseCase)
  - [x] Android build successful
  - [ ] Manual testing on device/emulator:
    - [ ] Home screen realtime card shows top consumers with instant power
    - [ ] Home screen statistics card shows top daily consumers with energy values
    - [ ] Dashboard shows top consumers for selected time range
    - [ ] Pull to refresh updates top consumers
    - [ ] Top consumers load on first screen open
    - [ ] Offline devices are excluded
    - [ ] Production devices are excluded
    - [ ] Device icons display correctly
    - [ ] Values formatted correctly (W/kW and Wh/kWh)
    - [ ] Works in both light and dark themes