### PR TITLE
 fix(home): use today (midnight to now) for daily top consumers

### DIFF
--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/home/HomeViewModel.kt
@@ -15,6 +15,9 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.toLocalDateTime
 import net.thevenot.comwatt.domain.FetchCurrentSiteUseCase
 import net.thevenot.comwatt.domain.FetchElectricityPriceUseCase
 import net.thevenot.comwatt.domain.FetchSiteDailyDataUseCase
@@ -147,10 +150,18 @@ class HomeViewModel(
                     }
                 )
 
-                // Fetch top daily consumers
+                // Fetch top daily consumers (today: midnight to now)
+                val now = Clock.System.now()
+                val todayStart = now.toLocalDateTime(TimeZone.currentSystemDefault())
+                    .date
+                    .atStartOfDayIn(TimeZone.currentSystemDefault())
+                    .let { kotlin.time.Instant.fromEpochMilliseconds(it.toEpochMilliseconds()) }
+
                 fetchTopConsumersUseCase.execute(
                     limit = 2,
-                    sortBy = ConsumerMetric.DAILY_ENERGY
+                    sortBy = ConsumerMetric.CUSTOM_RANGE,
+                    startTime = todayStart,
+                    endTime = now
                 ).fold(
                     ifLeft = { error ->
                         Logger.e(TAG) { "Failed to fetch top daily consumers: $error" }
@@ -224,10 +235,18 @@ class HomeViewModel(
                 }
             )
 
-            // Fetch top daily consumers
+            // Fetch top daily consumers (today: midnight to now)
+            val now = Clock.System.now()
+            val todayStart = now.toLocalDateTime(TimeZone.currentSystemDefault())
+                .date
+                .atStartOfDayIn(TimeZone.currentSystemDefault())
+                .let { kotlin.time.Instant.fromEpochMilliseconds(it.toEpochMilliseconds()) }
+
             fetchTopConsumersUseCase.execute(
                 limit = 2,
-                sortBy = ConsumerMetric.DAILY_ENERGY
+                sortBy = ConsumerMetric.CUSTOM_RANGE,
+                startTime = todayStart,
+                endTime = now
             ).fold(
                 ifLeft = { error ->
                     Logger.e(TAG) { "Failed to fetch top daily consumers: $error" }


### PR DESCRIPTION
## Problem

  The daily statistics card on the home screen shows data for "today" (midnight to now), but the top consumers were using "past 24 hours" (rolling window). This created an inconsistency where the top consumers list didn't match the statistics timeframe.

  Example at 2 PM:
  - ❌ Before: Top consumers showed data from yesterday 2 PM to today 2 PM
  - ✅ After: Top consumers show data from today midnight to today 2 PM

  ## Solution

  Changed the daily top consumers fetch to use `CUSTOM_RANGE` with:
  - `startTime` = start of today (midnight)
  - `endTime` = current time

  This ensures consistency between the daily statistics card and the top consumers list.

  ## Changes

  - Updated `HomeViewModel.kt` to calculate today's time range (midnight to now)
  - Changed from `ConsumerMetric.DAILY_ENERGY` to `ConsumerMetric.CUSTOM_RANGE`
  - Added kotlinx.datetime imports for time calculations

  ## Why This Matters

  - **Consistency**: Both statistics and top consumers now show the same timeframe
  - **User clarity**: Helps users understand their consumption "today so far"
  - **Actionable**: More useful for making decisions about today's energy usage