### PR TITLE
feat(dashboard): device filter + chart sort, with bottom-sheet controls

### DIFF
--- a/shared/src/commonMain/composeResources/drawable/ic_filter_list.xml
+++ b/shared/src/commonMain/composeResources/drawable/ic_filter_list.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M400,720L400,640L560,640L560,720L400,720ZM240,520L240,440L720,440L720,520L240,520ZM120,320L120,240L840,240L840,320L120,320Z" />
+</vector>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -91,6 +91,10 @@
     <string name="dashboard_filter_devices_label">Filter Devices</string>
     <string name="dashboard_filter_sheet_title">Filter devices</string>
     <string name="dashboard_filter_select_all">All devices</string>
+    <string name="dashboard_sort_label">Sort</string>
+    <string name="dashboard_sort_name">Name</string>
+    <string name="dashboard_sort_consumption_desc">Cons ↓</string>
+    <string name="dashboard_sort_consumption_asc">Cons ↑</string>
     <string name="no_content_available_retry_button">Retry</string>
     <string name="no_content_available_text">No Content Available</string>
     <string name="user_settings_panel_logout_button">Logout</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -88,6 +88,9 @@
     <string name="dashboard_chart_statistics_expand_icon_description_expanded">Collapse</string>
     <string name="dashboard_chart_statistics_expand_icon_description_collapsed">Expand</string>
     <string name="dashboard_chart_fullscreen_button_description">View chart in fullscreen</string>
+    <string name="dashboard_filter_devices_label">Filter Devices</string>
+    <string name="dashboard_filter_sheet_title">Filter devices</string>
+    <string name="dashboard_filter_select_all">All devices</string>
     <string name="no_content_available_retry_button">Retry</string>
     <string name="no_content_available_text">No Content Available</string>
     <string name="user_settings_panel_logout_button">Logout</string>

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/DataRepository.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/DataRepository.kt
@@ -43,6 +43,10 @@ class DataRepository(
         settingsRepository.saveDashboardHiddenDevices(devices)
     }
 
+    suspend fun saveDashboardSortMode(mode: String) {
+        settingsRepository.saveDashboardSortMode(mode)
+    }
+
     fun getSettings(): Flow<SolarEcoSettings> {
         return settingsRepository.settings
     }

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/DataRepository.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/DataRepository.kt
@@ -39,6 +39,10 @@ class DataRepository(
         settingsRepository.saveDashboardSelectedTimeUnitIndex(index)
     }
 
+    suspend fun saveDashboardHiddenDevices(devices: Set<String>) {
+        settingsRepository.saveDashboardHiddenDevices(devices)
+    }
+
     fun getSettings(): Flow<SolarEcoSettings> {
         return settingsRepository.settings
     }
@@ -52,6 +56,7 @@ class DataRepository(
                     is Either.Left -> {
                         onFail(authenticateResponse.value.errorMessage)
                     }
+
                     is Either.Right -> {
                         withContext(Dispatchers.Main) {
                             onLogin()

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/database/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/database/SettingsRepository.kt
@@ -4,6 +4,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -13,14 +14,18 @@ class SettingsRepository(
     private val siteKey = intPreferencesKey("site_id")
     private val maxPowerGaugeKey = intPreferencesKey("max_power_gauge")
     private val productionNoiseThresholdKey = intPreferencesKey("production_noise_threshold")
-    private val dashboardSelectedTimeUnitIndex = intPreferencesKey("dashboard_selected_time_unit_index")
+    private val dashboardSelectedTimeUnitIndex =
+        intPreferencesKey("dashboard_selected_time_unit_index")
+    private val dashboardHiddenDevicesKey =
+        stringSetPreferencesKey("dashboard_hidden_devices")
 
     val settings: Flow<SolarEcoSettings> = dataStore.data.map {
         SolarEcoSettings(
             siteId = it[siteKey],
             dashboardSelectedTimeUnitIndex = it[dashboardSelectedTimeUnitIndex],
             maxPowerGauge = it[maxPowerGaugeKey],
-            productionNoiseThreshold = it[productionNoiseThresholdKey]
+            productionNoiseThreshold = it[productionNoiseThresholdKey],
+            dashboardHiddenDevices = it[dashboardHiddenDevicesKey]
         )
     }
 
@@ -59,6 +64,14 @@ class SettingsRepository(
     ) {
         dataStore.edit {
             it[dashboardSelectedTimeUnitIndex] = index
+        }
+    }
+
+    suspend fun saveDashboardHiddenDevices(
+        devices: Set<String>,
+    ) {
+        dataStore.edit {
+            it[dashboardHiddenDevicesKey] = devices
         }
     }
 }

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/database/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/database/SettingsRepository.kt
@@ -4,6 +4,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -18,6 +19,8 @@ class SettingsRepository(
         intPreferencesKey("dashboard_selected_time_unit_index")
     private val dashboardHiddenDevicesKey =
         stringSetPreferencesKey("dashboard_hidden_devices")
+    private val dashboardSortModeKey =
+        stringPreferencesKey("dashboard_sort_mode")
 
     val settings: Flow<SolarEcoSettings> = dataStore.data.map {
         SolarEcoSettings(
@@ -25,7 +28,8 @@ class SettingsRepository(
             dashboardSelectedTimeUnitIndex = it[dashboardSelectedTimeUnitIndex],
             maxPowerGauge = it[maxPowerGaugeKey],
             productionNoiseThreshold = it[productionNoiseThresholdKey],
-            dashboardHiddenDevices = it[dashboardHiddenDevicesKey]
+            dashboardHiddenDevices = it[dashboardHiddenDevicesKey],
+            dashboardSortMode = it[dashboardSortModeKey]
         )
     }
 
@@ -72,6 +76,14 @@ class SettingsRepository(
     ) {
         dataStore.edit {
             it[dashboardHiddenDevicesKey] = devices
+        }
+    }
+
+    suspend fun saveDashboardSortMode(
+        mode: String,
+    ) {
+        dataStore.edit {
+            it[dashboardSortModeKey] = mode
         }
     }
 }

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/database/SolarEcoSettings.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/database/SolarEcoSettings.kt
@@ -4,5 +4,6 @@ data class SolarEcoSettings(
     val siteId: Int?,
     val dashboardSelectedTimeUnitIndex: Int?,
     val maxPowerGauge: Int?,
-    val productionNoiseThreshold: Int?
+    val productionNoiseThreshold: Int?,
+    val dashboardHiddenDevices: Set<String>?
 )

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/database/SolarEcoSettings.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/database/SolarEcoSettings.kt
@@ -5,5 +5,6 @@ data class SolarEcoSettings(
     val dashboardSelectedTimeUnitIndex: Int?,
     val maxPowerGauge: Int?,
     val productionNoiseThreshold: Int?,
-    val dashboardHiddenDevices: Set<String>?
+    val dashboardHiddenDevices: Set<String>?,
+    val dashboardSortMode: String?
 )

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreen.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreen.kt
@@ -307,9 +307,10 @@ fun DashboardScreenContent(
                     }
 
                     if (charts.isNotEmpty()) {
-                        val filteredCharts = charts.filterNot { chart ->
+                        val visibleCharts = charts.filterNot { chart ->
                             chart.name?.trim() in uiState.hiddenDevices
                         }
+                        val filteredCharts = sortDashboardCharts(visibleCharts, uiState.sortMode)
 
                         items(
                             items = filteredCharts.withIndex()

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreen.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreen.kt
@@ -1100,13 +1100,15 @@ fun DeviceFilterSheetPreview() {
     val sampleStateNoFilter = DashboardScreenState(
         isDataLoaded = true,
         availableDevices = sampleDevices,
-        hiddenDevices = emptySet()
+        hiddenDevices = emptySet(),
+        sortMode = DashboardSortMode.NAME
     )
 
     val sampleStateWithFilter = DashboardScreenState(
         isDataLoaded = true,
         availableDevices = sampleDevices,
-        hiddenDevices = setOf("Heat Pump", "Dishwasher")
+        hiddenDevices = setOf("Heat Pump", "Dishwasher"),
+        sortMode = DashboardSortMode.CONSUMPTION_DESC
     )
 
     ComwattTheme {

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreen.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreen.kt
@@ -574,6 +574,7 @@ private fun DeviceFilterSheet(
  * Pure content of the device filter sheet, extracted so it can be rendered in previews
  * without a real [ModalBottomSheet].
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun DeviceFilterSheetContent(
     uiState: DashboardScreenState,

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreen.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreen.kt
@@ -1,6 +1,7 @@
 package net.thevenot.comwatt.ui.dashboard
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -10,6 +11,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -17,19 +19,27 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ButtonGroupDefaults
 import androidx.compose.material3.Card
-import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.TriStateCheckbox
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedIconButton
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.ToggleButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
@@ -47,6 +57,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
@@ -86,6 +97,9 @@ import comwatt.shared.generated.resources.dashboard_chart_statistics_max_title
 import comwatt.shared.generated.resources.dashboard_chart_statistics_min_title
 import comwatt.shared.generated.resources.dashboard_chart_statistics_sum_title
 import comwatt.shared.generated.resources.dashboard_chart_statistics_title
+import comwatt.shared.generated.resources.dashboard_filter_devices_label
+import comwatt.shared.generated.resources.dashboard_filter_select_all
+import comwatt.shared.generated.resources.dashboard_filter_sheet_title
 import comwatt.shared.generated.resources.dashboard_screen_title
 import comwatt.shared.generated.resources.day_range_selected_time_n_days_gao
 import comwatt.shared.generated.resources.day_range_selected_time_today
@@ -124,9 +138,7 @@ import net.thevenot.comwatt.domain.model.TimeSeries
 import net.thevenot.comwatt.domain.model.TimeSeriesTitle
 import net.thevenot.comwatt.domain.model.TimeSeriesType
 import net.thevenot.comwatt.ui.common.CenteredTitleWithIcon
-import net.thevenot.comwatt.ui.common.ConsumerDisplayMode
 import net.thevenot.comwatt.ui.common.LoadingView
-import net.thevenot.comwatt.ui.common.TopConsumersCard
 import net.thevenot.comwatt.ui.dashboard.types.DashboardTimeUnit
 import net.thevenot.comwatt.ui.home.statistics.StatisticsCard
 import net.thevenot.comwatt.ui.nav.NestedAppScaffold
@@ -188,6 +200,7 @@ fun DashboardScreenContent(
         }
     }
     val showDatePickerDialog = remember { mutableStateOf(false) }
+    val showFilterSheet = remember { mutableStateOf(false) }
     val charts by viewModel.charts.collectAsState()
     val uiState by viewModel.uiState.collectAsState()
     val state = rememberPullToRefreshState()
@@ -209,6 +222,15 @@ fun DashboardScreenContent(
             })
     }
 
+    if (showFilterSheet.value) {
+        DeviceFilterSheet(
+            uiState = uiState,
+            onDeviceToggle = { viewModel.toggleDeviceVisibility(it) },
+            onSetAllVisible = { viewModel.setAllDevicesVisible(it) },
+            onDismiss = { showFilterSheet.value = false }
+        )
+    }
+
     NestedAppScaffold(
         navController = navController,
         title = {
@@ -216,6 +238,12 @@ fun DashboardScreenContent(
                 icon = AppIcons.LineAxis,
                 title = stringResource(Res.string.dashboard_screen_title),
                 iconContentDescription = "Statistics Icon"
+            )
+        },
+        actionsContent = {
+            DeviceFilterButton(
+                uiState = uiState,
+                onClick = { showFilterSheet.value = true }
             )
         },
         snackbarHostState = snackbarHostState,
@@ -279,8 +307,12 @@ fun DashboardScreenContent(
                     }
 
                     if (charts.isNotEmpty()) {
+                        val filteredCharts = charts.filterNot { chart ->
+                            chart.name?.trim() in uiState.hiddenDevices
+                        }
+
                         items(
-                            items = charts.withIndex()
+                            items = filteredCharts.withIndex()
                                 .filter { it.value.timeSeries.any { series -> series.values.isNotEmpty() } },
                             key = { it.index to it.value.name }) { (index, chart) ->
                             LazyGraphCard(
@@ -467,6 +499,159 @@ private fun TimeUnitBar(
                     },
             ) {
                 Text(label, maxLines = 1)
+            }
+        }
+    }
+}
+
+/**
+ * Top-app-bar trigger for the device filter. Shows a badge with the number of hidden
+ * devices. Renders nothing until devices are available to filter.
+ */
+@Composable
+private fun DeviceFilterButton(
+    uiState: DashboardScreenState,
+    onClick: () -> Unit = {}
+) {
+    if (uiState.availableDevices.isEmpty()) return
+
+    val hiddenCount = uiState.hiddenDevices.size
+
+    BadgedBox(
+        badge = {
+            if (hiddenCount > 0) {
+                Badge { Text(hiddenCount.toString()) }
+            }
+        }
+    ) {
+        IconButton(onClick = onClick) {
+            Icon(
+                painter = AppIcons.FilterList,
+                contentDescription = stringResource(Res.string.dashboard_filter_devices_label)
+            )
+        }
+    }
+}
+
+/**
+ * Modal bottom sheet listing every available device with its image and a checkbox.
+ * Checked = visible; unchecking adds the device to the hidden set (hide-list semantics).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DeviceFilterSheet(
+    uiState: DashboardScreenState,
+    onDeviceToggle: (String) -> Unit = {},
+    onSetAllVisible: (Boolean) -> Unit = {},
+    onDismiss: () -> Unit = {}
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        DeviceFilterSheetContent(
+            uiState = uiState,
+            onDeviceToggle = onDeviceToggle,
+            onSetAllVisible = onSetAllVisible
+        )
+    }
+}
+
+/**
+ * Pure content of the device filter sheet, extracted so it can be rendered in previews
+ * without a real [ModalBottomSheet].
+ */
+@Composable
+private fun DeviceFilterSheetContent(
+    uiState: DashboardScreenState,
+    onDeviceToggle: (String) -> Unit = {},
+    onSetAllVisible: (Boolean) -> Unit = {}
+) {
+    val hiddenCount = uiState.hiddenDevices.size
+    val allState = when (hiddenCount) {
+        0 -> ToggleableState.On
+        uiState.availableDevices.size -> ToggleableState.Off
+        else -> ToggleableState.Indeterminate
+    }
+
+    Column(
+        modifier = Modifier.fillMaxWidth()
+            .padding(bottom = AppTheme.dimens.paddingNormal)
+    ) {
+        Text(
+            text = stringResource(Res.string.dashboard_filter_sheet_title),
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.fillMaxWidth()
+                .padding(horizontal = AppTheme.dimens.paddingNormal)
+        )
+
+        HorizontalDivider(
+            modifier = Modifier.padding(vertical = AppTheme.dimens.paddingSmall)
+        )
+
+        // "All devices" tristate header: tapping shows all when not all shown,
+        // otherwise hides all.
+        Row(
+            modifier = Modifier.fillMaxWidth()
+                .clickable { onSetAllVisible(allState != ToggleableState.On) }
+                .padding(
+                    horizontal = AppTheme.dimens.paddingNormal,
+                    vertical = AppTheme.dimens.paddingSmall
+                ),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(AppTheme.dimens.paddingNormal)
+        ) {
+            Text(
+                text = stringResource(Res.string.dashboard_filter_select_all),
+                style = MaterialTheme.typography.titleSmall,
+                modifier = Modifier.weight(1f)
+            )
+            TriStateCheckbox(
+                state = allState,
+                onClick = { onSetAllVisible(allState != ToggleableState.On) }
+            )
+        }
+
+        HorizontalDivider(
+            modifier = Modifier.padding(vertical = AppTheme.dimens.paddingSmall)
+        )
+
+        Column(
+            modifier = Modifier.fillMaxWidth()
+                .heightIn(max = 400.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            uiState.availableDevices.keys.sorted().forEach { deviceName ->
+                val iconKey = uiState.availableDevices[deviceName]
+                val isVisible = deviceName !in uiState.hiddenDevices
+
+                Row(
+                    modifier = Modifier.fillMaxWidth()
+                        .clickable { onDeviceToggle(deviceName) }
+                        .padding(
+                            horizontal = AppTheme.dimens.paddingNormal,
+                            vertical = AppTheme.dimens.paddingSmall
+                        ),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(AppTheme.dimens.paddingNormal)
+                ) {
+                    Icon(
+                        painter = IconsUtil.mapIconKeyToPainter(iconKey),
+                        contentDescription = null,
+                        modifier = Modifier.size(24.dp)
+                    )
+                    Text(
+                        text = deviceName,
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Checkbox(
+                        checked = isVisible,
+                        onCheckedChange = { onDeviceToggle(deviceName) }
+                    )
+                }
             }
         }
     }
@@ -848,6 +1033,53 @@ private fun TimeSeriesStatisticsRow(
             modifier = Modifier.weight(1f),
             textAlign = androidx.compose.ui.text.style.TextAlign.Center
         )
+    }
+}
+
+@Preview
+@Composable
+fun DeviceFilterSheetPreview() {
+    val sampleDevices = mapOf(
+        "Solar Panel" to "icon-ico-sun",
+        "Kitchen" to "icon-ap-householdappliance",
+        "Heat Pump" to "icon-ap-heatpump",
+        "EV Charger" to "icon-ap-plug",
+        "Dishwasher" to "icon-ap-dishwasher"
+    )
+
+    val sampleStateNoFilter = DashboardScreenState(
+        isDataLoaded = true,
+        availableDevices = sampleDevices,
+        hiddenDevices = emptySet()
+    )
+
+    val sampleStateWithFilter = DashboardScreenState(
+        isDataLoaded = true,
+        availableDevices = sampleDevices,
+        hiddenDevices = setOf("Heat Pump", "Dishwasher")
+    )
+
+    ComwattTheme {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(vertical = AppTheme.dimens.paddingNormal),
+            verticalArrangement = Arrangement.spacedBy(AppTheme.dimens.paddingLarge)
+        ) {
+            Text(
+                "Nothing hidden",
+                style = MaterialTheme.typography.titleSmall,
+                modifier = Modifier.padding(horizontal = AppTheme.dimens.paddingNormal)
+            )
+            DeviceFilterSheetContent(uiState = sampleStateNoFilter)
+
+            HorizontalDivider()
+
+            Text(
+                "Two devices hidden",
+                style = MaterialTheme.typography.titleSmall,
+                modifier = Modifier.padding(horizontal = AppTheme.dimens.paddingNormal)
+            )
+            DeviceFilterSheetContent(uiState = sampleStateWithFilter)
+        }
     }
 }
 

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreen.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreen.kt
@@ -35,6 +35,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedIconButton
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -101,6 +104,10 @@ import comwatt.shared.generated.resources.dashboard_filter_devices_label
 import comwatt.shared.generated.resources.dashboard_filter_select_all
 import comwatt.shared.generated.resources.dashboard_filter_sheet_title
 import comwatt.shared.generated.resources.dashboard_screen_title
+import comwatt.shared.generated.resources.dashboard_sort_consumption_asc
+import comwatt.shared.generated.resources.dashboard_sort_consumption_desc
+import comwatt.shared.generated.resources.dashboard_sort_label
+import comwatt.shared.generated.resources.dashboard_sort_name
 import comwatt.shared.generated.resources.day_range_selected_time_n_days_gao
 import comwatt.shared.generated.resources.day_range_selected_time_today
 import comwatt.shared.generated.resources.day_range_selected_time_yesterday
@@ -227,6 +234,7 @@ fun DashboardScreenContent(
             uiState = uiState,
             onDeviceToggle = { viewModel.toggleDeviceVisibility(it) },
             onSetAllVisible = { viewModel.setAllDevicesVisible(it) },
+            onSortSelected = { viewModel.setSortMode(it) },
             onDismiss = { showFilterSheet.value = false }
         )
     }
@@ -544,6 +552,7 @@ private fun DeviceFilterSheet(
     uiState: DashboardScreenState,
     onDeviceToggle: (String) -> Unit = {},
     onSetAllVisible: (Boolean) -> Unit = {},
+    onSortSelected: (DashboardSortMode) -> Unit = {},
     onDismiss: () -> Unit = {}
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -555,7 +564,8 @@ private fun DeviceFilterSheet(
         DeviceFilterSheetContent(
             uiState = uiState,
             onDeviceToggle = onDeviceToggle,
-            onSetAllVisible = onSetAllVisible
+            onSetAllVisible = onSetAllVisible,
+            onSortSelected = onSortSelected
         )
     }
 }
@@ -568,7 +578,8 @@ private fun DeviceFilterSheet(
 private fun DeviceFilterSheetContent(
     uiState: DashboardScreenState,
     onDeviceToggle: (String) -> Unit = {},
-    onSetAllVisible: (Boolean) -> Unit = {}
+    onSetAllVisible: (Boolean) -> Unit = {},
+    onSortSelected: (DashboardSortMode) -> Unit = {}
 ) {
     val hiddenCount = uiState.hiddenDevices.size
     val allState = when (hiddenCount) {
@@ -587,6 +598,43 @@ private fun DeviceFilterSheetContent(
             modifier = Modifier.fillMaxWidth()
                 .padding(horizontal = AppTheme.dimens.paddingNormal)
         )
+
+        HorizontalDivider(
+            modifier = Modifier.padding(vertical = AppTheme.dimens.paddingSmall)
+        )
+
+        Column(
+            modifier = Modifier.fillMaxWidth()
+                .padding(horizontal = AppTheme.dimens.paddingNormal)
+        ) {
+            Text(
+                text = stringResource(Res.string.dashboard_sort_label),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(AppTheme.dimens.paddingSmall))
+
+            val sortOptions = listOf(
+                DashboardSortMode.NAME to stringResource(Res.string.dashboard_sort_name),
+                DashboardSortMode.CONSUMPTION_DESC to stringResource(Res.string.dashboard_sort_consumption_desc),
+                DashboardSortMode.CONSUMPTION_ASC to stringResource(Res.string.dashboard_sort_consumption_asc),
+            )
+
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                sortOptions.forEachIndexed { index, (mode, label) ->
+                    SegmentedButton(
+                        selected = uiState.sortMode == mode,
+                        onClick = { onSortSelected(mode) },
+                        shape = SegmentedButtonDefaults.itemShape(
+                            index = index,
+                            count = sortOptions.size
+                        )
+                    ) {
+                        Text(label, maxLines = 1)
+                    }
+                }
+            }
+        }
 
         HorizontalDivider(
             modifier = Modifier.padding(vertical = AppTheme.dimens.paddingSmall)

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreenState.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreenState.kt
@@ -23,7 +23,9 @@ data class DashboardScreenState(
     val selectedTimeRange: SelectedTimeRange = SelectedTimeRange(),
     val rangeStats: SiteDailyData? = null,
     val expandedCards: Set<String> = emptySet(),
-    val topConsumers: List<DeviceUiModel> = emptyList()
+    val topConsumers: List<DeviceUiModel> = emptyList(),
+    val hiddenDevices: Set<String> = emptySet(),
+    val availableDevices: Map<String, String?> = emptyMap(), // deviceName to iconKey
 )
 
 data class SelectedTimeRange(

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreenState.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardScreenState.kt
@@ -26,6 +26,7 @@ data class DashboardScreenState(
     val topConsumers: List<DeviceUiModel> = emptyList(),
     val hiddenDevices: Set<String> = emptySet(),
     val availableDevices: Map<String, String?> = emptyMap(), // deviceName to iconKey
+    val sortMode: DashboardSortMode = DashboardSortMode.NAME,
 )
 
 data class SelectedTimeRange(

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardSortMode.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardSortMode.kt
@@ -1,0 +1,58 @@
+package net.thevenot.comwatt.ui.dashboard
+
+import net.thevenot.comwatt.domain.model.ChartTimeSeries
+import net.thevenot.comwatt.domain.model.TimeSeriesType
+
+/**
+ * Ordering applied to the Dashboard device charts. NAME preserves the default
+ * alphabetical order; the consumption modes rank by total energy over the range.
+ */
+enum class DashboardSortMode {
+    NAME,
+    CONSUMPTION_DESC,
+    CONSUMPTION_ASC,
+}
+
+/**
+ * Total consumption of a chart over the selected range, read from the fetch-time
+ * statistics. `statistics[i]` is positional to `timeSeries[i]`. Returns 0.0 when the
+ * chart has no consumption series or no statistics (e.g. a device with no data).
+ */
+fun ChartTimeSeries.consumptionSum(): Double {
+    val idx = timeSeries.indexOfFirst { it.type == TimeSeriesType.CONSUMPTION }
+    return if (idx >= 0) statistics.getOrNull(idx)?.sum ?: 0.0 else 0.0
+}
+
+/**
+ * Reorders [charts] per [mode], always keeping the first chart (the site-level
+ * consumption/production overview) pinned at index 0. Pure and Compose-free so it can
+ * be unit-tested. Ties in consumption modes are broken by name (case-insensitive).
+ */
+fun sortDashboardCharts(
+    charts: List<ChartTimeSeries>,
+    mode: DashboardSortMode,
+): List<ChartTimeSeries> {
+    if (charts.size <= 1) return charts
+
+    val overview = charts.first()
+    val devices = charts.drop(1)
+
+    val sorted = when (mode) {
+        DashboardSortMode.NAME ->
+            devices.sortedBy { it.name?.lowercase() ?: "" }
+
+        DashboardSortMode.CONSUMPTION_DESC ->
+            devices.sortedWith(
+                compareByDescending<ChartTimeSeries> { it.consumptionSum() }
+                    .thenBy { it.name?.lowercase() ?: "" }
+            )
+
+        DashboardSortMode.CONSUMPTION_ASC ->
+            devices.sortedWith(
+                compareBy<ChartTimeSeries> { it.consumptionSum() }
+                    .thenBy { it.name?.lowercase() ?: "" }
+            )
+    }
+
+    return listOf(overview) + sorted
+}

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardViewModel.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardViewModel.kt
@@ -80,6 +80,14 @@ class DashboardViewModel(
             _uiState.update { it.copy(hiddenDevices = devices) }
             Logger.d(TAG) { "Loaded hidden devices: $devices" }
         }
+
+        // Load sort mode
+        settings?.dashboardSortMode?.let { stored ->
+            val mode = DashboardSortMode.entries.find { it.name == stored }
+                ?: DashboardSortMode.NAME
+            _uiState.update { it.copy(sortMode = mode) }
+            Logger.d(TAG) { "Loaded sort mode: $mode" }
+        }
     }
 
     private suspend fun updateTimeRangeAndFetchData() {
@@ -261,6 +269,14 @@ class DashboardViewModel(
             _uiState.update { it.copy(hiddenDevices = newHidden) }
             dataRepository.saveDashboardHiddenDevices(newHidden)
             Logger.d(TAG) { "Set all devices visible=$visible, now hidden: $newHidden" }
+        }
+    }
+
+    fun setSortMode(mode: DashboardSortMode) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(sortMode = mode) }
+            dataRepository.saveDashboardSortMode(mode.name)
+            Logger.d(TAG) { "Sort mode set: $mode" }
         }
     }
 

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardViewModel.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardViewModel.kt
@@ -37,7 +37,7 @@ class DashboardViewModel(
     private val fetchTimeSeriesUseCase: FetchTimeSeriesUseCase,
     private val dataRepository: DataRepository,
     private val fetchTopConsumersUseCase: FetchTopConsumersUseCase
-): ViewModel() {
+) : ViewModel() {
     private var autoRefreshJob: Job? = null
 
     private val _charts = MutableStateFlow<List<ChartTimeSeries>>(listOf())
@@ -65,14 +65,20 @@ class DashboardViewModel(
     }
 
     private suspend fun loadSelectedTimeUnit() {
-        val selectedTimeUnitIndex =
-            dataRepository.getSettings().firstOrNull()?.dashboardSelectedTimeUnitIndex
+        val settings = dataRepository.getSettings().firstOrNull()
+        val selectedTimeUnitIndex = settings?.dashboardSelectedTimeUnitIndex
         Logger.d(TAG) { "startAutoRefresh selectedTimeUnitIndex $selectedTimeUnitIndex" }
 
         selectedTimeUnitIndex?.let { index ->
             val timeUnit = DashboardTimeUnit.entries.getOrNull(index) ?: DashboardTimeUnit.HOUR
             _uiState.update { it.copy(selectedTimeUnit = timeUnit) }
             Logger.d(TAG) { "startAutoRefresh selectedTimeUnit ${_uiState.value.selectedTimeUnit}" }
+        }
+
+        // Load hidden devices
+        settings?.dashboardHiddenDevices?.let { devices ->
+            _uiState.update { it.copy(hiddenDevices = devices) }
+            Logger.d(TAG) { "Loaded hidden devices: $devices" }
         }
     }
 
@@ -98,6 +104,17 @@ class DashboardViewModel(
         }.onRight { value ->
             _charts.value = value
             _uiState.update { state -> state.copy(callCount = _uiState.value.callCount + 1) }
+
+            // Update available devices with their icon keys
+            val deviceMap = value.mapNotNull { chart ->
+                chart.name?.trim()?.let { name ->
+                    val iconKey = chart.timeSeries.firstOrNull()?.title?.iconKey
+                    name to iconKey
+                }
+            }.toMap()
+            _uiState.update { state ->
+                state.copy(availableDevices = deviceMap)
+            }
         }
 
         _uiState.update { state ->
@@ -180,6 +197,7 @@ class DashboardViewModel(
             DashboardTimeUnit.HOUR,
             DashboardTimeUnit.DAY,
             DashboardTimeUnit.WEEK -> null
+
             DashboardTimeUnit.SIXHOUR -> timeRange.sixHour.start
             DashboardTimeUnit.CUSTOM -> timeRange.custom.start
         }
@@ -214,6 +232,36 @@ class DashboardViewModel(
         _uiState.update { it.copy(selectedTimeRange = range) }
         Logger.d(TAG) { "onTimeSelected range $range" }
         singleRefresh()
+    }
+    fun toggleDeviceVisibility(deviceName: String) {
+        viewModelScope.launch {
+            val currentHidden = _uiState.value.hiddenDevices
+            val newHidden = if (currentHidden.contains(deviceName)) {
+                currentHidden - deviceName
+            } else {
+                currentHidden + deviceName
+            }
+            _uiState.update { it.copy(hiddenDevices = newHidden) }
+            dataRepository.saveDashboardHiddenDevices(newHidden)
+            Logger.d(TAG) { "Device visibility toggled: $deviceName, now hidden: $newHidden" }
+        }
+    }
+
+    /**
+     * Shows or hides every available device at once. Showing all clears the hidden set;
+     * hiding all puts every known device name into it.
+     */
+    fun setAllDevicesVisible(visible: Boolean) {
+        viewModelScope.launch {
+            val newHidden = if (visible) {
+                emptySet()
+            } else {
+                _uiState.value.availableDevices.keys.toSet()
+            }
+            _uiState.update { it.copy(hiddenDevices = newHidden) }
+            dataRepository.saveDashboardHiddenDevices(newHidden)
+            Logger.d(TAG) { "Set all devices visible=$visible, now hidden: $newHidden" }
+        }
     }
 
     override fun onCleared() {

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/login/LoginScreen.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/login/LoginScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
@@ -37,9 +39,15 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
@@ -76,6 +84,8 @@ fun LoginScreen(
     val coroutineScope = rememberCoroutineScope()
     var passwordHidden by rememberSaveable { mutableStateOf(true) }
     val keyboardController = LocalSoftwareKeyboardController.current
+    val focusManager = LocalFocusManager.current
+    val passwordFocusRequester = remember { FocusRequester() }
 
     LaunchedEffect(Unit) {
         viewModel.tryAutoLogin(onLogin)
@@ -136,11 +146,21 @@ fun LoginScreen(
                             value = email,
                             onValueChange = viewModel::updateEmail,
                             label = { Text(stringResource(Res.string.email_placeholder)) },
-                            shape = RoundedCornerShape(percent = 100)
+                            shape = RoundedCornerShape(percent = 100),
+                            keyboardOptions = KeyboardOptions(
+                                keyboardType = KeyboardType.Email,
+                                imeAction = ImeAction.Next
+                            ),
+                            keyboardActions = KeyboardActions(
+                                onNext = { focusManager.moveFocus(FocusDirection.Down) }
+                            ),
+                            singleLine = true
                         )
                         Spacer(modifier = Modifier.height(8.dp))
                         OutlinedTextField(
-                            modifier = Modifier.fillMaxWidth(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .focusRequester(passwordFocusRequester),
                             value = password,
                             onValueChange = viewModel::updatePassword,
                             label = { Text(stringResource(Res.string.password_placeholder)) },
@@ -166,7 +186,18 @@ fun LoginScreen(
                                     )
                                 }
                             },
-                            shape = RoundedCornerShape(percent = 100)
+                            shape = RoundedCornerShape(percent = 100),
+                            keyboardOptions = KeyboardOptions(
+                                keyboardType = KeyboardType.Password,
+                                imeAction = ImeAction.Done
+                            ),
+                            keyboardActions = KeyboardActions(
+                                onDone = {
+                                    keyboardController?.hide()
+                                    viewModel.login(onLogin)
+                                }
+                            ),
+                            singleLine = true
                         )
                         Spacer(modifier = Modifier.height(8.dp))
                         Row(

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/theme/icons/AppIcons.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/ui/theme/icons/AppIcons.kt
@@ -26,6 +26,7 @@ import comwatt.shared.generated.resources.ic_electric_bolt
 import comwatt.shared.generated.resources.ic_electric_car
 import comwatt.shared.generated.resources.ic_electrical_services
 import comwatt.shared.generated.resources.ic_error
+import comwatt.shared.generated.resources.ic_filter_list
 import comwatt.shared.generated.resources.ic_freezer
 import comwatt.shared.generated.resources.ic_fridge
 import comwatt.shared.generated.resources.ic_fullscreen
@@ -145,6 +146,10 @@ object AppIcons {
     val Error: Painter
         @Composable
         get() = painterResource(Res.drawable.ic_error)
+
+    val FilterList: Painter
+        @Composable
+        get() = painterResource(Res.drawable.ic_filter_list)
 
     val ArrowBack: Painter
         @Composable

--- a/shared/src/commonTest/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardSortTest.kt
+++ b/shared/src/commonTest/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardSortTest.kt
@@ -83,6 +83,21 @@ class DashboardSortTest {
     }
 
     @Test
+    fun `overview stays pinned even when its consumption ranks lowest in DESC`() {
+        // Overview has the lowest consumption here; pinning must be positional, not value-based.
+        val lowOverview = consumptionChart("Overview", sum = 0.0)
+        val charts = listOf(
+            lowOverview,
+            consumptionChart("High", 50.0),
+            consumptionChart("Mid", 25.0),
+        )
+
+        val result = sortDashboardCharts(charts, DashboardSortMode.CONSUMPTION_DESC)
+
+        assertEquals(listOf("Overview", "High", "Mid"), result.map { it.name })
+    }
+
+    @Test
     fun `charts without consumption series rank as zero and fall to bottom in DESC`() {
         val charts = listOf(
             overview,

--- a/shared/src/commonTest/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardSortTest.kt
+++ b/shared/src/commonTest/kotlin/net/thevenot/comwatt/ui/dashboard/DashboardSortTest.kt
@@ -1,0 +1,121 @@
+package net.thevenot.comwatt.ui.dashboard
+
+import net.thevenot.comwatt.domain.model.ChartTimeSeries
+import net.thevenot.comwatt.domain.model.TimeSeries
+import net.thevenot.comwatt.domain.model.TimeSeriesTitle
+import net.thevenot.comwatt.domain.model.TimeSeriesType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DashboardSortTest {
+
+    private fun consumptionChart(
+        name: String,
+        sum: Double,
+        hasConsumption: Boolean = true,
+    ): ChartTimeSeries {
+        val series = if (hasConsumption) {
+            listOf(
+                TimeSeries(
+                    title = TimeSeriesTitle(name, null),
+                    type = TimeSeriesType.CONSUMPTION,
+                    values = emptyMap()
+                )
+            )
+        } else {
+            listOf(
+                TimeSeries(
+                    title = TimeSeriesTitle(name, null),
+                    type = TimeSeriesType.PRODUCTION,
+                    values = emptyMap()
+                )
+            )
+        }
+        val stats = if (hasConsumption) {
+            listOf(ChartStatistics(0.0, 0.0, 0.0, sum, false))
+        } else {
+            emptyList()
+        }
+        return ChartTimeSeries(name = name, timeSeries = series, statistics = stats)
+    }
+
+    private val overview = consumptionChart("Overview", sum = 9999.0)
+
+    @Test
+    fun `NAME mode sorts devices A to Z and pins overview first`() {
+        val charts = listOf(
+            overview,
+            consumptionChart("Zebra", 1.0),
+            consumptionChart("alpha", 2.0),
+        )
+
+        val result = sortDashboardCharts(charts, DashboardSortMode.NAME)
+
+        assertEquals(listOf("Overview", "alpha", "Zebra"), result.map { it.name })
+    }
+
+    @Test
+    fun `CONSUMPTION_DESC sorts most consuming first, overview pinned`() {
+        val charts = listOf(
+            overview,
+            consumptionChart("Low", 5.0),
+            consumptionChart("High", 50.0),
+            consumptionChart("Mid", 25.0),
+        )
+
+        val result = sortDashboardCharts(charts, DashboardSortMode.CONSUMPTION_DESC)
+
+        assertEquals(listOf("Overview", "High", "Mid", "Low"), result.map { it.name })
+    }
+
+    @Test
+    fun `CONSUMPTION_ASC sorts least consuming first, overview pinned`() {
+        val charts = listOf(
+            overview,
+            consumptionChart("Low", 5.0),
+            consumptionChart("High", 50.0),
+            consumptionChart("Mid", 25.0),
+        )
+
+        val result = sortDashboardCharts(charts, DashboardSortMode.CONSUMPTION_ASC)
+
+        assertEquals(listOf("Overview", "Low", "Mid", "High"), result.map { it.name })
+    }
+
+    @Test
+    fun `charts without consumption series rank as zero and fall to bottom in DESC`() {
+        val charts = listOf(
+            overview,
+            consumptionChart("NoData", 0.0, hasConsumption = false),
+            consumptionChart("Real", 10.0),
+        )
+
+        val result = sortDashboardCharts(charts, DashboardSortMode.CONSUMPTION_DESC)
+
+        assertEquals(listOf("Overview", "Real", "NoData"), result.map { it.name })
+    }
+
+    @Test
+    fun `equal consumption ties broken by name`() {
+        val charts = listOf(
+            overview,
+            consumptionChart("Beta", 10.0),
+            consumptionChart("Alpha", 10.0),
+        )
+
+        val result = sortDashboardCharts(charts, DashboardSortMode.CONSUMPTION_DESC)
+
+        assertEquals(listOf("Overview", "Alpha", "Beta"), result.map { it.name })
+    }
+
+    @Test
+    fun `empty list returns empty`() {
+        assertEquals(emptyList(), sortDashboardCharts(emptyList(), DashboardSortMode.NAME))
+    }
+
+    @Test
+    fun `single overview-only list is unchanged`() {
+        val charts = listOf(overview)
+        assertEquals(listOf("Overview"), sortDashboardCharts(charts, DashboardSortMode.NAME).map { it.name })
+    }
+}


### PR DESCRIPTION
## Summary

  Adds two dashboard features built around a single device-filter **modal bottom sheet**, plus a small login UX commit that rode along on this branch.

  ### 1. Device filter
  Filter which device charts appear on the Dashboard, without permanently consuming vertical space in the chart list.
  - Filter button in the top app bar (badge shows how many devices are hidden).
  - Tapping it opens a `ModalBottomSheet` listing each device with its image and a checkbox.
  - **Hide-list semantics:** checked = visible; unchecking hides. Empty set = all shown.
  - A tristate **"All devices"** header toggles show-all / hide-all.
  - The hidden set persists across sessions (DataStore).

  ### 2. Chart sort
  Reorder the device charts from within the same bottom sheet.
  - A segmented control with three modes: **Name** (A→Z, default), **Cons ↓** (most consuming), **Cons ↑** (least consuming).
  - Consumption ranking reuses the **fetch-time statistics** already computed for the expandable cards — no extra API calls; sorting is a pure view-time transform applied after the hidden-device filter.
  - The site-level **overview chart stays pinned** at the top regardless of sort mode.
  - Charts with no consumption data rank as 0 and fall to the bottom; ties break by name.
  - The chosen mode persists across sessions (DataStore, stored as the enum name with a null-safe restore).

  ### 3. Login (pre-existing on this branch)
  `feat(login): add keyboard actions` — Email field uses `ImeAction.Next`, password uses `ImeAction.Done` to submit; focus management between fields; both fields single-line.

  ## Implementation notes
  - New `DashboardSortMode` enum + pure `sortDashboardCharts()` helper, kept Compose-free for unit testing.
  - New `ic_filter_list` drawable + `AppIcons.FilterList`.
  - Persistence threads through `SolarEcoSettings` → `SettingsRepository` → `DataRepository`, mirroring the existing settings pattern.
  - New user-facing strings (English source; translated separately via Crowdin).

  ## Test plan
  - [x] `./gradlew :shared:desktopTest` — green (incl. 8 `DashboardSortTest` cases: all 3 modes, overview pinning is positional not value-based, missing-consumption → bottom, tie-break by name, empty/single-item lists)
  - [x] `./gradlew :shared:compileKotlinDesktop` — clean
  - [ ] Manual: open Dashboard → filter sheet, hide/show devices, toggle "All devices", switch sort modes; confirm reorder + overview stays first; kill & relaunch app to confirm both filter and sort persist
  - [ ] Check the filter sheet + segmented control render on Android / iOS / Desktop (Compose `@Preview`: `DeviceFilterSheetPreview`)