### PR TITLE
fix(widget): align chart Y axis with the in-app chart

### DIFF
--- a/shared/src/androidMain/kotlin/net/thevenot/comwatt/widget/ChartImageGenerator.android.kt
+++ b/shared/src/androidMain/kotlin/net/thevenot/comwatt/widget/ChartImageGenerator.android.kt
@@ -37,15 +37,17 @@ class AndroidChartImageGenerator : ChartImageGenerator {
             val colors = Colors(isDarkMode)
             val chartBounds = ChartBounds(widthPx.toFloat(), heightPx.toFloat())
 
-            drawGridLines(canvas, chartBounds, colors.grid)
-
             val consumptions = data.consumptions.takeLast(60)
             val productions = data.productions.takeLast(60)
             val maxDataPoints = max(consumptions.size, productions.size)
             val maxValue = max(
                 max(data.maxConsumption, consumptions.maxOrNull() ?: 1.0),
                 max(data.maxProduction, productions.maxOrNull() ?: 1.0)
-            )
+            ).takeIf { it > 0.0 } ?: 1.0
+            val axisValues = ChartAxis.axisValues(maxValue)
+
+            drawGridLines(canvas, chartBounds, axisValues, maxValue, colors.grid)
+
             val stepX =
                 if (maxDataPoints > 1) chartBounds.width / (maxDataPoints - 1) else chartBounds.width
 
@@ -56,7 +58,7 @@ class AndroidChartImageGenerator : ChartImageGenerator {
                 drawDataLine(canvas, consumptions, colors.consumption, chartBounds, stepX, maxValue)
             }
 
-            drawYAxisLabels(canvas, chartBounds, maxValue, colors.text)
+            drawYAxisLabels(canvas, chartBounds, axisValues, maxValue, colors.text)
 
             val outputStream = ByteArrayOutputStream()
             bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
@@ -70,7 +72,13 @@ class AndroidChartImageGenerator : ChartImageGenerator {
         }
     }
 
-    private fun drawGridLines(canvas: Canvas, bounds: ChartBounds, gridColor: Int) {
+    private fun drawGridLines(
+        canvas: Canvas,
+        bounds: ChartBounds,
+        axisValues: List<Double>,
+        maxValue: Double,
+        gridColor: Int
+    ) {
         val paint = Paint().apply {
             color = gridColor
             style = Paint.Style.STROKE
@@ -78,9 +86,8 @@ class AndroidChartImageGenerator : ChartImageGenerator {
             isAntiAlias = true
         }
 
-        val gridLineCount = 4
-        for (i in 0..gridLineCount) {
-            val y = bounds.bottom - (i.toFloat() / gridLineCount) * bounds.height
+        axisValues.forEach { value ->
+            val y = bounds.yFor(value, maxValue)
             canvas.drawLine(bounds.left, y, bounds.right, y, paint)
         }
     }
@@ -121,8 +128,7 @@ class AndroidChartImageGenerator : ChartImageGenerator {
 
         data.forEachIndexed { index, value ->
             val x = bounds.left + index * stepX
-            val normalizedValue = (value / maxValue).coerceIn(0.0, 1.0)
-            val y = bounds.bottom - (normalizedValue * bounds.height).toFloat()
+            val y = bounds.yFor(value, maxValue)
 
             if (index == 0) {
                 linePath.moveTo(x, y)
@@ -147,6 +153,7 @@ class AndroidChartImageGenerator : ChartImageGenerator {
     private fun drawYAxisLabels(
         canvas: Canvas,
         bounds: ChartBounds,
+        axisValues: List<Double>,
         maxValue: Double,
         textColor: Int
     ) {
@@ -157,12 +164,9 @@ class AndroidChartImageGenerator : ChartImageGenerator {
             textAlign = Paint.Align.RIGHT
         }
 
-        val gridLineCount = 4
-        for (i in 0..gridLineCount) {
-            val value = (i.toFloat() / gridLineCount) * maxValue
-            val y = bounds.bottom - (i.toFloat() / gridLineCount) * bounds.height
-            val label = if (value >= 1000) "${(value / 1000).toInt()}k" else "${value.toInt()}"
-            canvas.drawText(label, bounds.left - 6f, y + 6f, paint)
+        axisValues.forEach { value ->
+            val y = bounds.yFor(value, maxValue)
+            canvas.drawText(ChartAxis.formatLabel(value), bounds.left - 6f, y + 6f, paint)
         }
     }
 
@@ -185,6 +189,9 @@ class AndroidChartImageGenerator : ChartImageGenerator {
         val bottom = canvasHeight - paddingBottom
         val width = right - left
         val height = bottom - top
+
+        fun yFor(value: Double, maxValue: Double): Float =
+            bottom - ((value / maxValue).coerceIn(0.0, 1.0) * height).toFloat()
     }
 }
 

--- a/shared/src/commonMain/kotlin/net/thevenot/comwatt/widget/ChartAxis.kt
+++ b/shared/src/commonMain/kotlin/net/thevenot/comwatt/widget/ChartAxis.kt
@@ -1,0 +1,35 @@
+package net.thevenot.comwatt.widget
+
+import kotlin.math.floor
+import kotlin.math.log10
+import kotlin.math.pow
+
+/**
+ * Y axis helpers shared by the widget chart renderers.
+ *
+ * These mirror the in-app chart (`DashboardScreen`), which fixes the Y range to
+ * `0..maxValue` and places labels on a "nice step" of 10^floor(log10(maxValue)).
+ * Keeping the same rule here means a value of 3532 W is labelled 0 / 1k / 2k / 3k
+ * in both places, with the peak drawn above the 3k line.
+ */
+object ChartAxis {
+    /** Tick values from 0 up to (and not beyond) [maxValue], on a power-of-ten step. */
+    fun axisValues(maxValue: Double): List<Double> {
+        if (maxValue <= 0.0 || !maxValue.isFinite()) return listOf(0.0)
+
+        val step = 10.0.pow(floor(log10(maxValue)))
+        if (step <= 0.0 || !step.isFinite()) return listOf(0.0, maxValue)
+
+        val values = mutableListOf<Double>()
+        var value = 0.0
+        while (value <= maxValue) {
+            values.add(value)
+            value += step
+        }
+        return values
+    }
+
+    /** Formats a tick value, abbreviating thousands the way the app's axis does. */
+    fun formatLabel(value: Double): String =
+        if (value >= 1000) "${(value / 1000).toInt()}k" else "${value.toInt()}"
+}

--- a/shared/src/commonTest/kotlin/net/thevenot/comwatt/widget/ChartAxisTest.kt
+++ b/shared/src/commonTest/kotlin/net/thevenot/comwatt/widget/ChartAxisTest.kt
@@ -1,0 +1,60 @@
+package net.thevenot.comwatt.widget
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ChartAxisTest {
+    @Test
+    fun axisValuesUsePowerOfTenSteps() {
+        val testCases = listOf(
+            3532.0 to listOf(0.0, 1000.0, 2000.0, 3000.0),
+            2308.0 to listOf(0.0, 1000.0, 2000.0),
+            900.0 to listOf(0.0, 100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, 900.0),
+            999.0 to listOf(0.0, 100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, 900.0),
+            12.0 to listOf(0.0, 10.0),
+            1.0 to listOf(0.0, 1.0)
+        )
+
+        for ((maxValue, expected) in testCases) {
+            assertEquals(expected, ChartAxis.axisValues(maxValue), "Failed for max: $maxValue")
+        }
+    }
+
+    @Test
+    fun axisValuesIncludeExactMaxWhenItIsAMultipleOfTheStep() {
+        assertEquals(listOf(0.0, 1000.0, 2000.0, 3000.0), ChartAxis.axisValues(3000.0))
+    }
+
+    @Test
+    fun axisValuesNeverExceedMax() {
+        for (maxValue in listOf(1.0, 12.0, 900.0, 2308.0, 3532.0, 10000.0)) {
+            val values = ChartAxis.axisValues(maxValue)
+            assertEquals(
+                emptyList(),
+                values.filter { it > maxValue },
+                "Ticks above max for $maxValue"
+            )
+        }
+    }
+
+    @Test
+    fun axisValuesHandleNonPositiveMax() {
+        assertEquals(listOf(0.0), ChartAxis.axisValues(0.0))
+        assertEquals(listOf(0.0), ChartAxis.axisValues(-5.0))
+    }
+
+    @Test
+    fun formatLabelAbbreviatesThousands() {
+        val testCases = listOf(
+            0.0 to "0",
+            883.0 to "883",
+            1000.0 to "1k",
+            2000.0 to "2k",
+            3000.0 to "3k"
+        )
+
+        for ((value, expected) in testCases) {
+            assertEquals(expected, ChartAxis.formatLabel(value), "Failed for value: $value")
+        }
+    }
+}


### PR DESCRIPTION
The widget chart placed grid lines and labels at quarter fractions of the data max, then truncated them when abbreviating thousands. With a peak of 3532 W the ticks were 0/883/1766/2649/3532, rendered as 0/883/1k/2k/3k -- so "1k" was really 1766 W and the top "3k" was the peak itself, making the widget look like it started at 3k while the app showed the peak above its 3k line.

Extract the app's "nice step" rule (10^floor(log10(max))) into a shared ChartAxis helper and use it for the widget grid lines and labels, so both charts label 0/1k/2k/3k for the same data. Also route the data lines through the same value-to-Y mapping as the grid.